### PR TITLE
Remove C#6 features the build infrastructure doesn't understand.

### DIFF
--- a/src/Microsoft.Owin.Host.SystemWeb/SystemWebChunkingCookieManager.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/SystemWebChunkingCookieManager.cs
@@ -21,12 +21,13 @@ namespace Microsoft.Owin.Host.SystemWeb
         {
             ChunkSize = 4090;
             ThrowForPartialCookies = true;
+            Fallback = new ChunkingCookieManager();
         }
 
         /// <summary>
         /// A fallback manager used if HttpContextBase can't be located.
         /// </summary>
-        public ICookieManager Fallback { get; set; } = new ChunkingCookieManager();
+        public ICookieManager Fallback { get; set; }
 
         /// <summary>
         /// The maximum size of cookie to send back to the client. If a cookie exceeds this size it will be broken down into multiple
@@ -259,7 +260,7 @@ namespace Microsoft.Owin.Host.SystemWeb
 
             var requestCookies = webContext.Request.Cookies;
             var cookie = requestCookies[escapedKey];
-            string requestCookie = cookie?.Value;
+            string requestCookie = (cookie == null ? null : cookie.Value);
 
             int chunks = ParseChunksCount(requestCookie);
 

--- a/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
@@ -12,9 +12,17 @@ namespace Microsoft.Owin.Host.SystemWeb
     public class SystemWebCookieManager : ICookieManager
     {
         /// <summary>
+        /// Creates a new instance of SystemWebCookieManager.
+        /// </summary>
+        public SystemWebCookieManager()
+        {
+            Fallback = new CookieManager();
+        }
+
+        /// <summary>
         /// A fallback manager used if HttpContextBase can't be located.
         /// </summary>
-        public ICookieManager Fallback { get; set; } = new CookieManager();
+        public ICookieManager Fallback { get; set; }
 
         /// <summary>
         /// Reads the requested cookie from System.Web.HttpContextBase.Request.Cookies.
@@ -37,7 +45,11 @@ namespace Microsoft.Owin.Host.SystemWeb
 
             var escapedKey = Uri.EscapeDataString(key);
             var cookie = webContext.Request.Cookies[escapedKey];
-            return Uri.UnescapeDataString(cookie?.Value);
+            if (cookie == null)
+            {
+                return null;
+            }
+            return Uri.UnescapeDataString(cookie.Value);
         }
 
         /// <summary>

--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Owin.Security.Facebook
     /// </summary>
     public class FacebookAuthenticationOptions : AuthenticationOptions
     {
+        private IList<string> _fields;
+
         /// <summary>
         /// Initializes a new <see cref="FacebookAuthenticationOptions"/>
         /// </summary>
@@ -27,7 +29,8 @@ namespace Microsoft.Owin.Security.Facebook
             Scope = new List<string>();
             BackchannelTimeout = TimeSpan.FromSeconds(60);
             SendAppSecretProof = true;
-            Fields = new List<string>();
+            _fields = new List<string>();
+            CookieManager = new CookieManager();
 
             AuthorizationEndpoint = Constants.AuthorizationEndpoint;
             TokenEndpoint = Constants.TokenEndpoint;
@@ -131,11 +134,14 @@ namespace Microsoft.Owin.Security.Facebook
         /// The list of fields to retrieve from the UserInformationEndpoint.
         /// https://developers.facebook.com/docs/graph-api/reference/user
         /// </summary>
-        public IList<string> Fields { get; }
+        public IList<string> Fields
+        {
+            get { return _fields; }
+        }
 
         /// <summary>
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
-        public ICookieManager CookieManager { get; set; } = new CookieManager();
+        public ICookieManager CookieManager { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationOptions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Owin.Security.Google
             AuthenticationMode = AuthenticationMode.Passive;
             Scope = new List<string>();
             BackchannelTimeout = TimeSpan.FromSeconds(60);
+            CookieManager = new CookieManager();
         }
 
         /// <summary>
@@ -110,6 +111,6 @@ namespace Microsoft.Owin.Security.Google
         /// <summary>
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
-        public ICookieManager CookieManager { get; set; } = new CookieManager();
+        public ICookieManager CookieManager { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/MicrosoftAccountAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/MicrosoftAccountAuthenticationOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
             AuthenticationMode = AuthenticationMode.Passive;
             Scope = new List<string>();
             BackchannelTimeout = TimeSpan.FromSeconds(60);
+            CookieManager = new CookieManager();
         }
 
         /// <summary>
@@ -105,6 +106,6 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
         /// <summary>
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
-        public ICookieManager CookieManager { get; set; } = new CookieManager();
+        public ICookieManager CookieManager { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
             Scope = OpenIdConnectScopes.OpenIdProfile;
             TokenValidationParameters = new TokenValidationParameters();
             UseTokenLifetime = true;
+            CookieManager = new CookieManager();
         }
 
         /// <summary>
@@ -287,6 +288,6 @@ namespace Microsoft.Owin.Security.OpenIdConnect
         /// <summary>
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
-        public ICookieManager CookieManager { get; set; } = new CookieManager();
+        public ICookieManager CookieManager { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationOptions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Owin.Security.Twitter
             CallbackPath = new PathString("/signin-twitter");
             AuthenticationMode = AuthenticationMode.Passive;
             BackchannelTimeout = TimeSpan.FromSeconds(60);
+            CookieManager = new CookieManager();
         }
 
         /// <summary>
@@ -99,6 +100,6 @@ namespace Microsoft.Owin.Security.Twitter
         /// <summary>
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
-        public ICookieManager CookieManager { get; set; } = new CookieManager();
+        public ICookieManager CookieManager { get; set; }
     }
 }

--- a/src/Microsoft.Owin/Infrastructure/ChunkingCookieManager.cs
+++ b/src/Microsoft.Owin/Infrastructure/ChunkingCookieManager.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Owin.Infrastructure
     /// </summary>
     public class ChunkingCookieManager : ICookieManager
     {
+        /// <summary>
+        /// Creates a new instance of ChunkingCookieManager.
+        /// </summary>
         public ChunkingCookieManager()
         {
             ChunkSize = 4090;


### PR DESCRIPTION
(Replaces CodeFlow PR)
Katana/Sake build automation is hard-coded to old build tools (msbuild 4, stylecop) that do not understand C#6. It's not worth updating the infrastructure, we can do without these features.