### PR TITLE
[WIP] IdentityModel dependency update for OpenIdConnect, WsFed, and Bearer

### DIFF
--- a/build/CommonAssemblyInfo.cs
+++ b/build/CommonAssemblyInfo.cs
@@ -8,6 +8,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("\x00a9 Microsoft Corporation All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.60210.0")]
-[assembly: AssemblyInformationalVersion("4.0.0-alpha1-60210-000")]
+[assembly: AssemblyFileVersion("4.0.60801.0")]
+[assembly: AssemblyInformationalVersion("4.0.0-alpha1-60801-000")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/build/DevAssemblyInfo.cs
+++ b/build/DevAssemblyInfo.cs
@@ -8,6 +8,6 @@ using System.Reflection;
 [assembly: AssemblyCopyright("\x00a9 Microsoft Corporation All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("0.31.0.0")]
-[assembly: AssemblyFileVersion("0.31.60210.0")]
-[assembly: AssemblyInformationalVersion("0.31.0-pre-60210-000")]
+[assembly: AssemblyFileVersion("0.31.60801.0")]
+[assembly: AssemblyInformationalVersion("0.31.0-pre-60801-000")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/build/Katana.version.targets
+++ b/build/Katana.version.targets
@@ -3,15 +3,15 @@
   <PropertyGroup>
     <ShipVersion>4.0.0</ShipVersion>
     <ShipStrongNameVersion>4.0.0.0</ShipStrongNameVersion>
-    <ShipFullVersion>4.0.0-alpha1-60210-000</ShipFullVersion>
-    <ShipFileVersion>4.0.60210.0</ShipFileVersion>
+    <ShipFullVersion>4.0.0-alpha1-60801-000</ShipFullVersion>
+    <ShipFileVersion>4.0.60801.0</ShipFileVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildQuality>alpha1</BuildQuality>
-    <BuildDate>60210</BuildDate>
+    <BuildDate>60801</BuildDate>
     <BranchSuffix></BranchSuffix>
-    <Eula>http://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</Eula>
+    <Eula>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</Eula>
     <ProjectUrl>https://github.com/aspnet/AspNetKatana/</ProjectUrl>
     <Tags>Microsoft OWIN Katana</Tags>
   </PropertyGroup>

--- a/build/Sakefile.shade
+++ b/build/Sakefile.shade
@@ -4,9 +4,8 @@ var AUTHORS='Microsoft'
 var SHIP='${Version(4, 0, 0, "alpha1")}'
 var DEV='${Version(0, 31, 0, "pre")}'
 set FINAL_MILESTONE='${false}'
-
-var AZUREAD_JWT_SUFFIX=''
-var AZUREAD_EXT_SUFFIX=''
+var AZUREAD_VERSION='5.2.0'
+var AZUREAD_SUFFIX='.407281058-pre'
 var VERSION='${SHIP.VERSION}'
 var FULL_VERSION='${SHIP.FULL_VERSION}'
 var EULA='https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm'
@@ -271,16 +270,15 @@ var signing='${new List<string>()}'
     test if='OFFICIAL_BUILD && !RELEASE_BUILD'
       -title = title.Split(new[]{"("}, StringSplitOptions.None)[0] + string.Format(" (nightly {0:yyyy MMM dd})", DateTime.Now);
 
-    var azureAdJwtSuffix='${AZUREAD_JWT_SUFFIX}'
-    set azureAdJwtSuffix='' if='OFFICIAL_BUILD && RELEASE_BUILD && FINAL_MILESTONE'
-    var azureAdExtSuffix='${AZUREAD_EXT_SUFFIX}'
-    set azureAdExtSuffix='' if='OFFICIAL_BUILD && RELEASE_BUILD && FINAL_MILESTONE'
+    var azureAdVersion='${AZUREAD_VERSION}'
+    var azureAdSuffix='${AZUREAD_SUFFIX}'
+    set azureAdSuffix='' if='OFFICIAL_BUILD && RELEASE_BUILD && FINAL_MILESTONE'
 
     var licenseUrl='${EULA}'
     var projectUrl='${PROJECT_URL}'
     var tags='${TAGS}'
 
-    nuget-pack nuspecFile='${file}' outputDir='${TARGET_DIR}' extra='-NoPackageAnalysis -Symbols -Properties "id=${baseName};authors=${AUTHORS};author=${AUTHORS};title=${title};description=${description};licenseUrl=${licenseUrl};projectUrl=${projectUrl};tags=${tags};azureAdJwtSuffix=${azureAdJwtSuffix};azureAdExtSuffix=${azureAdExtSuffix}"'
+    nuget-pack nuspecFile='${file}' outputDir='${TARGET_DIR}' extra='-NoPackageAnalysis -Symbols -Properties "id=${baseName};authors=${AUTHORS};author=${AUTHORS};title=${title};description=${description};licenseUrl=${licenseUrl};projectUrl=${projectUrl};tags=${tags};azureAdVersion=${azureAdVersion};azureAdSuffix=${azureAdSuffix}"'
 
 #nuget-deploy target='deploy' description='Upload NuGet packages to gallery'
   var extra=''

--- a/src/Microsoft.Owin.Security.ActiveDirectory/ActiveDirectoryFederationServicesBearerAuthenticationExtensions.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/ActiveDirectoryFederationServicesBearerAuthenticationExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Linq;
 using Microsoft.Owin.Security.ActiveDirectory;
 using Microsoft.Owin.Security.Jwt;
@@ -28,7 +27,7 @@ namespace Owin
                 throw new ArgumentNullException("options");
             }
 
-            var cachingSecurityTokenProvider = new WsFedCachingSecurityTokenProvider(options.MetadataEndpoint,
+            var cachingSecurityTokenProvider = new WsFedCachingSecurityKeyProvider(options.MetadataEndpoint,
                     options.BackchannelCertificateValidator, options.BackchannelTimeout, options.BackchannelHttpHandler);
 
 #pragma warning disable 618

--- a/src/Microsoft.Owin.Security.ActiveDirectory/ActiveDirectoryFederationServicesBearerAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/ActiveDirectoryFederationServicesBearerAuthenticationOptions.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
-
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.OAuth;
 
 namespace Microsoft.Owin.Security.ActiveDirectory

--- a/src/Microsoft.Owin.Security.ActiveDirectory/IssuerSigningKeys.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/IssuerSigningKeys.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Owin.Security.ActiveDirectory
 {
@@ -19,6 +19,6 @@ namespace Microsoft.Owin.Security.ActiveDirectory
         /// <summary>
         /// Signing tokens.
         /// </summary>
-        public IEnumerable<X509SecurityToken> Tokens { get; set; }
+        public IEnumerable<SecurityKey> Keys { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.csproj
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.csproj
@@ -40,6 +40,34 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.WsFederation, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.WsFederation.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.WsFederation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens.Saml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.Saml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.Saml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Xml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Xml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Xml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -47,10 +75,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
@@ -68,7 +95,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="WsFedCachingSecurityTokenProvider.cs" />
+    <Compile Include="WsFedCachingSecurityKeyProvider.cs" />
     <Compile Include="IssuerSigningKeys.cs" />
     <Compile Include="WsFedMetadataRetriever.cs" />
     <Compile Include="WindowsAzureActiveDirectoryBearerAuthenticationExtensions.cs" />

--- a/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.nuspec
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.nuspec
@@ -21,7 +21,7 @@
       <dependency id="Microsoft.Owin.Security" version="$version$" />
       <dependency id="Microsoft.Owin.Security.OAuth" version="$version$" />
       <dependency id="Microsoft.Owin.Security.Jwt" version="$version$" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.0$azureAdJwtSuffix$" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="$azureAdVersion$$azureAdSuffix$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WindowsAzureActiveDirectoryBearerAuthenticationExtensions.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WindowsAzureActiveDirectoryBearerAuthenticationExtensions.cs
@@ -40,7 +40,7 @@ namespace Owin
                 options.MetadataAddress = string.Format(CultureInfo.InvariantCulture, SecurityTokenServiceAddressFormat, options.Tenant);
             }
 
-            var cachingSecurityTokenProvider = new WsFedCachingSecurityTokenProvider(options.MetadataAddress,
+            var cachingSecurityTokenProvider = new WsFedCachingSecurityKeyProvider(options.MetadataAddress,
                         options.BackchannelCertificateValidator, options.BackchannelTimeout, options.BackchannelHttpHandler);
 
 #pragma warning disable 618

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WindowsAzureActiveDirectoryBearerAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WindowsAzureActiveDirectoryBearerAuthenticationOptions.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
-
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.OAuth;
 
 namespace Microsoft.Owin.Security.ActiveDirectory

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WsFedCachingSecurityKeyProvider.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WsFedCachingSecurityKeyProvider.cs
@@ -4,18 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IdentityModel.Tokens;
 using System.Net.Http;
 using System.Threading;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.Jwt;
 
 namespace Microsoft.Owin.Security.ActiveDirectory
 {
     /// <summary>
-    /// A security token provider which retrieves the issuer and signing tokens from a WSFed metadata endpoint.
+    /// A security key provider which retrieves the issuer and signing tokens from a WSFed metadata endpoint.
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "This type is only controlled through the interface, which is not disposable.")]
-    internal class WsFedCachingSecurityTokenProvider : IIssuerSecurityTokenProvider
+    internal class WsFedCachingSecurityKeyProvider : IIssuerSecurityKeyProvider
     {
         private readonly TimeSpan _refreshInterval = new TimeSpan(1, 0, 0, 0);
 
@@ -28,9 +28,9 @@ namespace Microsoft.Owin.Security.ActiveDirectory
 
         private string _issuer;
 
-        private IEnumerable<SecurityToken> _tokens;
+        private IEnumerable<SecurityKey> _keys;
 
-        public WsFedCachingSecurityTokenProvider(string metadataEndpoint, ICertificateValidator backchannelCertificateValidator,
+        public WsFedCachingSecurityKeyProvider(string metadataEndpoint, ICertificateValidator backchannelCertificateValidator,
             TimeSpan backchannelTimeout, HttpMessageHandler backchannelHttpHandler)
         {
             _metadataEndpoint = metadataEndpoint;
@@ -67,20 +67,21 @@ namespace Microsoft.Owin.Security.ActiveDirectory
         }
 
         /// <summary>
-        /// Gets all known security tokens.
+        /// Gets all known security keys.
         /// </summary>
         /// <value>
-        /// All known security tokens.
+        /// All known security keys.
         /// </value>
-        public IEnumerable<SecurityToken> SecurityTokens
+        public IEnumerable<SecurityKey> SecurityKeys
         {
             get
             {
                 RefreshMetadata();
-                return _tokens;
+                return _keys;
             }
         }
 
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Can't throw exceptions on a background thread.")]
         private void RefreshMetadata()
         {
             if (_syncAfter >= DateTimeOffset.UtcNow)
@@ -109,7 +110,7 @@ namespace Microsoft.Owin.Security.ActiveDirectory
             IssuerSigningKeys metaData = WsFedMetadataRetriever.GetSigningKeys(_metadataEndpoint,
                 _backchannelTimeout, _backchannelHttpHandler);
             _issuer = metaData.Issuer;
-            _tokens = metaData.Tokens;
+            _keys = metaData.Keys;
         }
     }
 }

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WsFedMetadataRetriever.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WsFedMetadataRetriever.cs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.IdentityModel.Metadata;
-using System.IdentityModel.Tokens;
+using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography.X509Certificates;
-using System.ServiceModel.Security;
 using System.Xml;
+using Microsoft.IdentityModel.Protocols.WsFederation;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Owin.Security.ActiveDirectory
 {
@@ -23,9 +20,6 @@ namespace Microsoft.Owin.Security.ActiveDirectory
 
         public static IssuerSigningKeys GetSigningKeys(string metadataEndpoint, TimeSpan backchannelTimeout, HttpMessageHandler backchannelHttpHandler)
         {
-            string issuer = string.Empty;
-            var tokens = new List<X509SecurityToken>();
-
             using (var metadataRequest = new HttpClient(backchannelHttpHandler, false))
             {
                 metadataRequest.Timeout = backchannelTimeout;
@@ -35,32 +29,13 @@ namespace Microsoft.Owin.Security.ActiveDirectory
                     Stream metadataStream = metadataResponse.Content.ReadAsStreamAsync().Result;
                     using (XmlReader metaDataReader = XmlReader.Create(metadataStream, SafeSettings))
                     {
-                        var serializer = new MetadataSerializer { CertificateValidationMode = X509CertificateValidationMode.None };
+                        var serializer = new WsFederationMetadataSerializer();
+                        var wsFederationConfiguration = serializer.ReadMetadata(metaDataReader);
 
-                        MetadataBase metadata = serializer.ReadMetadata(metaDataReader);
-                        var entityDescriptor = (EntityDescriptor)metadata;
-
-                        if (!string.IsNullOrWhiteSpace(entityDescriptor.EntityId.Id))
-                        {
-                            issuer = entityDescriptor.EntityId.Id;
-                        }
-
-                        SecurityTokenServiceDescriptor stsd = entityDescriptor.RoleDescriptors.OfType<SecurityTokenServiceDescriptor>().First();
-                        if (stsd == null)
-                        {
-                            throw new InvalidOperationException(Properties.Resources.Exception_MissingDescriptor);
-                        }
-
-                        IEnumerable<X509RawDataKeyIdentifierClause> x509DataClauses =
-                            stsd.Keys.Where(key => key.KeyInfo != null
-                                && (key.Use == KeyType.Signing || key.Use == KeyType.Unspecified))
-                                    .Select(key => key.KeyInfo.OfType<X509RawDataKeyIdentifierClause>().First());
-                        tokens.AddRange(x509DataClauses.Select(token => new X509SecurityToken(new X509Certificate2(token.GetX509RawData()))));
+                        return new IssuerSigningKeys { Issuer = wsFederationConfiguration.Issuer, Keys = wsFederationConfiguration.SigningKeys };
                     }
                 }
             }
-
-            return new IssuerSigningKeys { Issuer = issuer, Tokens = tokens };
         }
     }
 }

--- a/src/Microsoft.Owin.Security.ActiveDirectory/packages.config
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/packages.config
@@ -1,5 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols.WsFederation" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens.Saml" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Xml" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Owin.Security.Cookies/Microsoft.Owin.Security.Cookies.csproj
+++ b/src/Microsoft.Owin.Security.Cookies/Microsoft.Owin.Security.Cookies.csproj
@@ -42,7 +42,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.csproj
+++ b/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.csproj
@@ -37,9 +37,9 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.Facebook.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,7 +48,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>

--- a/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.nuspec
+++ b/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.nuspec
@@ -17,7 +17,7 @@
     </frameworkAssemblies>
     <dependencies>
       <dependency id="Owin" version="1.0" />
-      <dependency id="Newtonsoft.Json" version="6.0.4" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Owin" version="$version$" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
     </dependencies>

--- a/src/Microsoft.Owin.Security.Facebook/packages.config
+++ b/src/Microsoft.Owin.Security.Facebook/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.csproj
+++ b/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.csproj
@@ -35,9 +35,9 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.Google.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.nuspec
+++ b/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.nuspec
@@ -17,7 +17,7 @@
     </frameworkAssemblies>
     <dependencies>
       <dependency id="Owin" version="1.0" />
-      <dependency id="Newtonsoft.Json" version="6.0.4" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Owin" version="$version$" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
     </dependencies>

--- a/src/Microsoft.Owin.Security.Google/packages.config
+++ b/src/Microsoft.Owin.Security.Google/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Owin.Security.Jwt/IIssuerSecurityKeyProvider.cs
+++ b/src/Microsoft.Owin.Security.Jwt/IIssuerSecurityKeyProvider.cs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Owin.Security.Jwt
 {
     /// <summary>
-    /// Provides security token information to the implementing class.
+    /// Provides security key information to the implementing class.
     /// </summary>
-    public interface IIssuerSecurityTokenProvider
+    public interface IIssuerSecurityKeyProvider
     {
         /// <summary>
         /// Gets the issuer the credentials are for.
@@ -20,11 +20,11 @@ namespace Microsoft.Owin.Security.Jwt
         string Issuer { get; }
 
         /// <summary>
-        /// Gets all known security tokens.
+        /// Gets all known security keys.
         /// </summary>
         /// <value>
-        /// All known security tokens.
+        /// All known security keys.
         /// </value>
-        IEnumerable<SecurityToken> SecurityTokens { get; }
+        IEnumerable<SecurityKey> SecurityKeys { get; }
     }
 }

--- a/src/Microsoft.Owin.Security.Jwt/JwtBearerAuthenticationExtensions.cs
+++ b/src/Microsoft.Owin.Security.Jwt/JwtBearerAuthenticationExtensions.cs
@@ -36,7 +36,7 @@ namespace Owin
             }
             else
             {
-                jwtFormat = new JwtFormat(options.AllowedAudiences, options.IssuerSecurityTokenProviders);
+                jwtFormat = new JwtFormat(options.AllowedAudiences, options.IssuerSecurityKeyProviders);
             }
             if (options.TokenHandler != null)
             {

--- a/src/Microsoft.Owin.Security.Jwt/JwtBearerAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Jwt/JwtBearerAuthenticationOptions.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
-
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.OAuth;
 
 namespace Microsoft.Owin.Security.Jwt
@@ -36,7 +36,7 @@ namespace Microsoft.Owin.Security.Jwt
         /// <value>
         /// The issuer security token providers.
         /// </value>
-        public IEnumerable<IIssuerSecurityTokenProvider> IssuerSecurityTokenProviders { get; set; }
+        public IEnumerable<IIssuerSecurityKeyProvider> IssuerSecurityKeyProviders { get; set; }
 
         /// <summary>
         /// Gets or sets the authentication provider.

--- a/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.csproj
+++ b/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.csproj
@@ -36,6 +36,18 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.Jwt.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -43,18 +55,18 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\build\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="IIssuerSecurityTokenProvider.cs" />
+    <Compile Include="IIssuerSecurityKeyProvider.cs" />
     <Compile Include="JwtBearerAuthenticationExtensions.cs" />
     <Compile Include="JwtBearerAuthenticationOptions.cs" />
     <Compile Include="JwtFormat.cs" />
@@ -64,8 +76,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="SymmetricKeyIssuerSecurityTokenProvider.cs" />
-    <Compile Include="X509CertificateSecurityTokenProvider.cs" />
+    <Compile Include="SymmetricKeyIssuerSecurityKeyProvider.cs" />
+    <Compile Include="X509CertificateSecurityKeyProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Owin.Security.OAuth\Microsoft.Owin.Security.OAuth.csproj">

--- a/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.nuspec
+++ b/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.nuspec
@@ -16,7 +16,7 @@
       <dependency id="Microsoft.Owin" version="$version$" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
       <dependency id="Microsoft.Owin.Security.OAuth" version="$version$" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.0$azureAdJwtSuffix$" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="$azureAdVersion$$azureAdSuffix$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.Owin.Security.Jwt/SymmetricKeyIssuerSecurityKeyProvider.cs
+++ b/src/Microsoft.Owin.Security.Jwt/SymmetricKeyIssuerSecurityKeyProvider.cs
@@ -3,36 +3,35 @@
 
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
-using System.ServiceModel.Security.Tokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Owin.Security.Jwt
 {
     /// <summary>
-    /// Implements an <see cref="IIssuerSecurityTokenProvider"/> for symmetric key signed JWTs.
+    /// Implements an <see cref="IIssuerSecurityKeyProvider"/> for symmetric key signed JWTs.
     /// </summary>
-    public class SymmetricKeyIssuerSecurityTokenProvider : IIssuerSecurityTokenProvider
+    public class SymmetricKeyIssuerSecurityKeyProvider : IIssuerSecurityKeyProvider
     {
-        private readonly List<SecurityToken> _tokens = new List<SecurityToken>();
+        private readonly List<SecurityKey> _keys = new List<SecurityKey>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityTokenProvider"/> class.
+        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityKeyProvider"/> class.
         /// </summary>
         /// <param name="issuer">The issuer of a JWT token.</param>
         /// <param name="key">The symmetric key a JWT is signed with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when the issuer is null.</exception>
-        public SymmetricKeyIssuerSecurityTokenProvider(string issuer, byte[] key)
+        public SymmetricKeyIssuerSecurityKeyProvider(string issuer, byte[] key)
             : this(issuer, new[] { key })
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityTokenProvider"/> class.
+        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityKeyProvider"/> class.
         /// </summary>
         /// <param name="issuer">The issuer of a JWT token.</param>
         /// <param name="keys">Symmetric keys a JWT could be signed with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when the issuer is null.</exception>
-        public SymmetricKeyIssuerSecurityTokenProvider(string issuer, IEnumerable<byte[]> keys)
+        public SymmetricKeyIssuerSecurityKeyProvider(string issuer, IEnumerable<byte[]> keys)
         {
             if (string.IsNullOrWhiteSpace(issuer))
             {
@@ -46,27 +45,27 @@ namespace Microsoft.Owin.Security.Jwt
             Issuer = issuer;
             foreach (var key in keys)
             {
-                _tokens.Add(new BinarySecretSecurityToken(key));
+                _keys.Add(new SymmetricSecurityKey(key));
             }
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityTokenProvider"/> class.
+        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityKeyProvider"/> class.
         /// </summary>
         /// <param name="issuer">The issuer of a JWT token.</param>
         /// <param name="base64Key">The base64 encoded symmetric key a JWT is signed with.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when the issuer is null.</exception>
-        public SymmetricKeyIssuerSecurityTokenProvider(string issuer, string base64Key)
+        public SymmetricKeyIssuerSecurityKeyProvider(string issuer, string base64Key)
             : this(issuer, new[] { base64Key })
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityTokenProvider"/> class.
+        /// Initializes a new instance of the <see cref="SymmetricKeyIssuerSecurityKeyProvider"/> class.
         /// </summary>
         /// <param name="issuer">The issuer of a JWT token.</param>
         /// <param name="base64Keys">The base64 encoded symmetric keys a JWT could be signed with.</param>
-        public SymmetricKeyIssuerSecurityTokenProvider(string issuer, IEnumerable<string> base64Keys)
+        public SymmetricKeyIssuerSecurityKeyProvider(string issuer, IEnumerable<string> base64Keys)
         {
             if (string.IsNullOrWhiteSpace(issuer))
             {
@@ -80,7 +79,7 @@ namespace Microsoft.Owin.Security.Jwt
             Issuer = issuer;
             foreach (var key in base64Keys)
             {
-                _tokens.Add(new BinarySecretSecurityToken(Convert.FromBase64String(key)));
+                _keys.Add(new SymmetricSecurityKey(Convert.FromBase64String(key)));
             }
         }
 
@@ -93,14 +92,14 @@ namespace Microsoft.Owin.Security.Jwt
         public string Issuer { get; private set; }
 
         /// <summary>
-        /// Gets all known security tokens.
+        /// Gets all known security keys.
         /// </summary>
         /// <returns>
-        /// All known security tokens.
+        /// All known security keys.
         /// </returns>
-        public IEnumerable<SecurityToken> SecurityTokens
+        public IEnumerable<SecurityKey> SecurityKeys
         {
-            get { return _tokens.AsReadOnly(); }
+            get { return _keys.AsReadOnly(); }
         }
     }
 }

--- a/src/Microsoft.Owin.Security.Jwt/X509CertificateSecurityKeyProvider.cs
+++ b/src/Microsoft.Owin.Security.Jwt/X509CertificateSecurityKeyProvider.cs
@@ -3,20 +3,20 @@
 
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Owin.Security.Jwt
 {
     /// <summary>
-    /// Implements an <see cref="IIssuerSecurityTokenProvider"/> for X509 JWTs.
+    /// Implements an <see cref="IIssuerSecurityKeyProvider"/> for X509 JWTs.
     /// </summary>
-    public class X509CertificateSecurityTokenProvider : IIssuerSecurityTokenProvider
+    public class X509CertificateSecurityKeyProvider : IIssuerSecurityKeyProvider
     {
-        private readonly List<SecurityToken> _tokens = new List<SecurityToken>();
+        private readonly List<SecurityKey> _keys = new List<SecurityKey>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="X509CertificateSecurityTokenProvider"/> class.
+        /// Initializes a new instance of the <see cref="X509CertificateSecurityKeyProvider"/> class.
         /// </summary>
         /// <param name="issuer">The issuer.</param>
         /// <param name="certificate">The certificate.</param>
@@ -25,7 +25,7 @@ namespace Microsoft.Owin.Security.Jwt
         /// or
         /// certificate
         /// </exception>
-        public X509CertificateSecurityTokenProvider(string issuer, X509Certificate2 certificate)
+        public X509CertificateSecurityKeyProvider(string issuer, X509Certificate2 certificate)
         {
             if (string.IsNullOrWhiteSpace(issuer))
             {
@@ -39,7 +39,7 @@ namespace Microsoft.Owin.Security.Jwt
 
             Issuer = issuer;
 
-            _tokens.Add(new X509SecurityToken(certificate));
+            _keys.Add(new X509SecurityKey(certificate));
         }
 
         /// <summary>
@@ -51,14 +51,14 @@ namespace Microsoft.Owin.Security.Jwt
         public string Issuer { get; private set; }
 
         /// <summary>
-        /// Gets all known security tokens.
+        /// Gets all known security keys.
         /// </summary>
         /// <value>
-        /// All known security tokens.
+        /// All known security keys.
         /// </value>
-        public IEnumerable<SecurityToken> SecurityTokens
+        public IEnumerable<SecurityKey> SecurityKeys
         {
-            get { return _tokens.AsReadOnly(); }
+            get { return _keys.AsReadOnly(); }
         }
     }
 }

--- a/src/Microsoft.Owin.Security.Jwt/packages.config
+++ b/src/Microsoft.Owin.Security.Jwt/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.csproj
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.csproj
@@ -35,9 +35,9 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.MicrosoftAccount.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -46,7 +46,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.nuspec
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <dependency id="Owin" version="1.0" />
       <dependency id="Microsoft.Owin" version="$version$" />
-      <dependency id="Newtonsoft.Json" version="6.0.4" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
     </dependencies>
   </metadata>

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/packages.config
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.csproj
+++ b/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.csproj
@@ -36,9 +36,9 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.OAuth.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -46,7 +46,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.nuspec
+++ b/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.nuspec
@@ -14,7 +14,7 @@
     <dependencies>
       <dependency id="Owin" version="1.0" />
       <dependency id="Microsoft.Owin" version="$version$" />
-      <dependency id="Newtonsoft.Json" version="6.0.4" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
     </dependencies>
   </metadata>

--- a/src/Microsoft.Owin.Security.OAuth/packages.config
+++ b/src/Microsoft.Owin.Security.OAuth/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.csproj
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.csproj
@@ -39,18 +39,33 @@
     <CodeAnalysisRuleSet>..\..\build\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.nuspec
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.nuspec
@@ -21,8 +21,11 @@
       <dependency id="Owin" version="1.0" />
       <dependency id="Microsoft.Owin" version="$version$" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.0$azureAdJwtSuffix$" />
-      <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0$azureAdExtSuffix$" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="$azureAdVersion$$azureAdSuffix$" />
+      <dependency id="Microsoft.IdentityModel.Logging" version="$azureAdVersion$$azureAdSuffix$" />
+      <dependency id="Microsoft.IdentityModel.Protocols" version="$azureAdVersion$$azureAdSuffix$" />
+      <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="$azureAdVersion$$azureAdSuffix$" />
+      <dependency id="Microsoft.IdentityModel.Tokens" version="$azureAdVersion$$azureAdSuffix$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.Owin.Security.OpenIdConnect/Notifications/AuthorizationCodeReceivedNotification.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/Notifications/AuthorizationCodeReceivedNotification.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.IdentityModel.Tokens;
-using System.Security.Claims;
-using Microsoft.IdentityModel.Protocols;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin.Security.OpenIdConnect;
 
 namespace Microsoft.Owin.Security.Notifications

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationNotifications.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationNotifications.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin.Security.Notifications;
 
 namespace Microsoft.Owin.Security.OpenIdConnect

--- a/src/Microsoft.Owin.Security.OpenIdConnect/packages.config
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.csproj
+++ b/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.csproj
@@ -37,9 +37,9 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.Twitter.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,7 +48,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>

--- a/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.nuspec
+++ b/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.nuspec
@@ -18,7 +18,7 @@
     <dependencies>
       <dependency id="Owin" version="1.0" />
       <dependency id="Microsoft.Owin" version="$version$" />
-      <dependency id="Newtonsoft.Json" version="6.0.4" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
     </dependencies>
   </metadata>

--- a/src/Microsoft.Owin.Security.Twitter/packages.config
+++ b/src/Microsoft.Owin.Security.Twitter/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.csproj
+++ b/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.csproj
@@ -37,18 +37,41 @@
     <DocumentationFile>bin\Release\Microsoft.Owin.Security.WsFederation.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.WsFederation, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.WsFederation.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.WsFederation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens.Saml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.Saml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.Saml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Xml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Xml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Xml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.nuspec
+++ b/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.nuspec
@@ -21,8 +21,8 @@
       <dependency id="Owin" version="1.0" />
       <dependency id="Microsoft.Owin" version="$version$" />
       <dependency id="Microsoft.Owin.Security" version="$version$" />
-      <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.0$azureAdJwtSuffix$" />
-      <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0$azureAdExtSuffix$" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="$azureAdVersion$$azureAdSuffix$" />
+      <dependency id="Microsoft.IdentityModel.Protocols.WsFederation" version="$azureAdVersion$$azureAdSuffix$" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationDefaults.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationDefaults.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Owin.Security.WsFederation
 {
     /// <summary>

--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationMiddleware.cs
@@ -2,10 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
-using Microsoft.IdentityModel.Extensions;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsFederation;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Tokens.Saml2;
 using Microsoft.Owin.Logging;
 using Microsoft.Owin.Security.DataHandler;
 using Microsoft.Owin.Security.DataProtection;
@@ -46,11 +51,6 @@ namespace Microsoft.Owin.Security.WsFederation
                 Options.StateDataFormat = new PropertiesDataFormat(dataProtector);
             }
 
-            if (Options.SecurityTokenHandlers == null)
-            {
-                Options.SecurityTokenHandlers = SecurityTokenHandlerCollectionExtensions.GetDefaultHandlers();
-            }
-
             if (Options.Notifications == null)
             {
                 Options.Notifications = new WsFederationAuthenticationNotifications();
@@ -74,7 +74,8 @@ namespace Microsoft.Owin.Security.WsFederation
                     HttpClient httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
                     httpClient.Timeout = Options.BackchannelTimeout;
                     httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
-                    Options.ConfigurationManager = new ConfigurationManager<WsFederationConfiguration>(Options.MetadataAddress, httpClient);
+                    Options.ConfigurationManager = new ConfigurationManager<WsFederationConfiguration>(Options.MetadataAddress,
+                        new WsFederationConfigurationRetriever(), httpClient);
                 }
             }
         }

--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationNotifications.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationNotifications.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsFederation;
 using Microsoft.Owin.Security.Notifications;
 
 namespace Microsoft.Owin.Security.WsFederation

--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationOptions.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
-using Microsoft.IdentityModel.Extensions;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsFederation;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Microsoft.Owin.Security.WsFederation
 {
@@ -15,7 +20,12 @@ namespace Microsoft.Owin.Security.WsFederation
     /// </summary>
     public class WsFederationAuthenticationOptions : AuthenticationOptions
     {
-        private SecurityTokenHandlerCollection _securityTokenHandlers;
+        private ICollection<ISecurityTokenValidator> _securityTokenHandlers = new Collection<ISecurityTokenValidator>()
+        {
+            new Saml2SecurityTokenHandler(),
+            new SamlSecurityTokenHandler(),
+            new JwtSecurityTokenHandler()
+        };
         private TokenValidationParameters _tokenValidationParameters;
 
         /// <summary>
@@ -112,7 +122,7 @@ namespace Microsoft.Owin.Security.WsFederation
         /// </summary>
         [SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly", Justification = "By design")]
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "By design")]
-        public SecurityTokenHandlerCollection SecurityTokenHandlers
+        public ICollection<ISecurityTokenValidator> SecurityTokenHandlers
         {
             get
             {

--- a/src/Microsoft.Owin.Security.WsFederation/packages.config
+++ b/src/Microsoft.Owin.Security.WsFederation/packages.config
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols.WsFederation" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens.Saml" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Xml" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
 </packages>

--- a/src/Microsoft.Owin.Security/DataHandler/Serializer/TicketSerializer.cs
+++ b/src/Microsoft.Owin.Security/DataHandler/Serializer/TicketSerializer.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IdentityModel.Tokens;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -71,15 +70,15 @@ namespace Microsoft.Owin.Security.DataHandler.Serializer
                 WriteWithDefault(writer, claim.OriginalIssuer, claim.Issuer);
             }
 
-            BootstrapContext bc = identity.BootstrapContext as BootstrapContext;
-            if (bc == null || string.IsNullOrWhiteSpace(bc.Token))
+            var bc = identity.BootstrapContext as string;
+            if (bc == null || string.IsNullOrWhiteSpace(bc))
             {
                 writer.Write(0);
             }
             else
             {
-                writer.Write(bc.Token.Length);
-                writer.Write(bc.Token);
+                writer.Write(bc.Length);
+                writer.Write(bc);
             }
             PropertiesSerializer.Write(writer, model.Properties);
         }
@@ -114,7 +113,7 @@ namespace Microsoft.Owin.Security.DataHandler.Serializer
             int bootstrapContextSize = reader.ReadInt32();
             if (bootstrapContextSize > 0)
             {
-                identity.BootstrapContext = new BootstrapContext(reader.ReadString());
+                identity.BootstrapContext = reader.ReadString();
             }
 
             AuthenticationProperties properties = PropertiesSerializer.Read(reader);

--- a/src/Microsoft.Owin.Security/Microsoft.Owin.Security.csproj
+++ b/src/Microsoft.Owin.Security/Microsoft.Owin.Security.csproj
@@ -49,7 +49,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Security" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/tests/FunctionalTests/Facts/Security/ActiveDirectory/WaadAuthentication.cs
+++ b/tests/FunctionalTests/Facts/Security/ActiveDirectory/WaadAuthentication.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IdentityModel.Tokens;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using FunctionalTests.Common;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.ActiveDirectory;
 using Owin;

--- a/tests/FunctionalTests/Facts/Security/BearerToken/SymmetricJwtTokenAuthentication.cs
+++ b/tests/FunctionalTests/Facts/Security/BearerToken/SymmetricJwtTokenAuthentication.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IdentityModel.Tokens;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -11,6 +10,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using FunctionalTests.Common;
 using FunctionalTests.Facts.Security.Common;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Jwt;
 using Microsoft.Owin.Security.OAuth;
@@ -69,7 +69,7 @@ namespace FunctionalTests.Facts.Security.BearerToken
             var SymmetricJwtOptions = new JwtBearerAuthenticationOptions()
             {
                 AllowedAudiences = new string[] { issuer },
-                IssuerSecurityTokenProviders = new IIssuerSecurityTokenProvider[] { new SymmetricKeyIssuerSecurityTokenProvider(issuer, signingAlgorithm.Key) },
+                IssuerSecurityKeyProviders = new IIssuerSecurityKeyProvider[] { new SymmetricKeyIssuerSecurityKeyProvider(issuer, signingAlgorithm.Key) },
                 Provider = new OAuthBearerAuthenticationProvider()
                 {
                     OnRequestToken = context =>
@@ -99,7 +99,7 @@ namespace FunctionalTests.Facts.Security.BearerToken
                         new AuthenticationTicket(identity, new AuthenticationProperties() { ExpiresUtc = DateTime.UtcNow }) :
                         new AuthenticationTicket(identity, new AuthenticationProperties() { ExpiresUtc = DateTime.UtcNow.AddYears(4) });
 
-                    var signingCredentials = new SigningCredentials(new InMemorySymmetricSecurityKey(signingAlgorithm.Key), SecurityAlgorithms.HmacSha256Signature, SecurityAlgorithms.Sha256Digest);
+                    var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(signingAlgorithm.Key), SecurityAlgorithms.HmacSha256Signature, SecurityAlgorithms.Sha256Digest);
                     await context.Response.WriteAsync(SecurityUtils.CreateJwtToken(ticket, issuer, signingCredentials));
                 });
             });

--- a/tests/FunctionalTests/Facts/Security/Common/SecurityUtils.cs
+++ b/tests/FunctionalTests/Facts/Security/Common/SecurityUtils.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IdentityModel.Protocols.WSTrust;
-using System.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security;
 
 namespace FunctionalTests.Facts.Security.Common
@@ -45,14 +45,18 @@ namespace FunctionalTests.Facts.Security.Common
                 new Claim("jti", Guid.NewGuid().ToString("N"))
             });
 
-            Lifetime lifetime = new Lifetime(null, null);
-            if (data.Properties.IssuedUtc != null || data.Properties.ExpiresUtc != null)
+            var tokenDescriptor = new SecurityTokenDescriptor()
             {
-                lifetime = new Lifetime(data.Properties.IssuedUtc != null ? (DateTime?)((DateTimeOffset)data.Properties.IssuedUtc).UtcDateTime : null, data.Properties.ExpiresUtc != null ? (DateTime?)((DateTimeOffset)data.Properties.ExpiresUtc).UtcDateTime : null);
-            }
+                Audience = audience,
+                Expires = data.Properties.ExpiresUtc.HasValue ? new DateTime?(data.Properties.ExpiresUtc.Value.UtcDateTime) : null,
+                Issuer = issuer,
+                IssuedAt = data.Properties.IssuedUtc.HasValue ? new DateTime?(data.Properties.IssuedUtc.Value.UtcDateTime) : null,
+                SigningCredentials = signingCredentials,
+                Subject = identity
+            };
 
             var handler = new JwtSecurityTokenHandler();
-            return handler.CreateToken(issuer, audience, identity, lifetime.Created, lifetime.Expires, signingCredentials).RawData;
+            return handler.CreateJwtSecurityToken(tokenDescriptor).RawData;
         }
 
         private static string GetEpocTimeStamp()

--- a/tests/FunctionalTests/Facts/Security/Jwt/SymmetricKeyTokenVerification.cs
+++ b/tests/FunctionalTests/Facts/Security/Jwt/SymmetricKeyTokenVerification.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using FunctionalTests.Facts.Security.Common;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Jwt;
 using Xunit;
@@ -29,9 +30,9 @@ namespace FunctionalTests.Facts.Security.Jwt
             var sentTicket = new AuthenticationTicket(sentIdentity, authProperties);
 
             var signingAlgorithm = new AesManaged();
-            var signingCredentials = new SigningCredentials(new InMemorySymmetricSecurityKey(signingAlgorithm.Key), SecurityAlgorithms.HmacSha256Signature, SecurityAlgorithms.Sha256Digest);
+            var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(signingAlgorithm.Key), SecurityAlgorithms.HmacSha256Signature, SecurityAlgorithms.Sha256Digest);
             var tokenValidationParameters = new TokenValidationParameters() { ValidAudience = issuer, SaveSigninToken = true, AuthenticationType = sentIdentity.AuthenticationType };
-            var formatter = new JwtFormat(tokenValidationParameters, new SymmetricKeyIssuerSecurityTokenProvider(issuer, signingAlgorithm.Key));
+            var formatter = new JwtFormat(tokenValidationParameters, new SymmetricKeyIssuerSecurityKeyProvider(issuer, signingAlgorithm.Key));
             formatter.TokenHandler = new JwtSecurityTokenHandler();
 
             var protectedtext = SecurityUtils.CreateJwtToken(sentTicket, issuer, signingCredentials);
@@ -44,7 +45,7 @@ namespace FunctionalTests.Facts.Security.Jwt
             Assert.Equal<string>(ClaimsIdentity.DefaultNameClaimType, receivedTicket.Identity.NameClaimType);
             Assert.Equal<string>(ClaimsIdentity.DefaultRoleClaimType, receivedTicket.Identity.RoleClaimType);
             Assert.NotNull(receivedTicket.Identity.BootstrapContext);
-            Assert.NotNull(((BootstrapContext)receivedTicket.Identity.BootstrapContext).Token);
+            Assert.NotNull((receivedTicket.Identity.BootstrapContext) as string);
             Assert.Equal<string>(issuer, receivedClaims.Where<Claim>(claim => claim.Type == "iss").FirstOrDefault().Value);
             Assert.Equal<string>(issuer, receivedClaims.Where<Claim>(claim => claim.Type == "aud").FirstOrDefault().Value);
             Assert.NotEmpty(receivedClaims.Where<Claim>(claim => claim.Type == "exp").FirstOrDefault().Value);

--- a/tests/FunctionalTests/FunctionalTests.csproj
+++ b/tests/FunctionalTests/FunctionalTests.csproj
@@ -36,17 +36,37 @@
     <Reference Include="LTAF.Infrastructure">
       <HintPath>..\..\packages\LTAF.Infrastructure.1.0.7\lib\Net40\LTAF.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.WsFederation, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.WsFederation.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Protocols.WsFederation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens.Saml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.Saml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.Saml.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Xml, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Xml.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Xml.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.1.31002.9028, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -57,10 +77,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/tests/FunctionalTests/Properties/AssemblyInfo.cs
+++ b/tests/FunctionalTests/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("0.31.0.0")]
 [assembly: AssemblyVersion("0.31.0.0")]
-[assembly: AssemblyFileVersion("0.31.60210.0")]
+[assembly: AssemblyFileVersion("0.31.60801.0")]

--- a/tests/FunctionalTests/packages.config
+++ b/tests/FunctionalTests/packages.config
@@ -1,12 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="LTAF.Infrastructure" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Protocols.WsFederation" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens.Saml" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Xml" version="5.2.0.407281058-pre" targetFramework="net451" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Core" version="2.1.0" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />

--- a/tests/Katana.Sandbox.WebServer/Katana.Sandbox.WebServer.csproj
+++ b/tests/Katana.Sandbox.WebServer/Katana.Sandbox.WebServer.csproj
@@ -42,18 +42,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -120,13 +120,12 @@ namespace Katana.Sandbox.WebServer
             });
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             */
-            /*
+            
             app.UseWsFederationAuthentication(new WsFederationAuthenticationOptions()
             {
-                Wtrealm = "http://Katana.Sandbox.WebServer",
+                Wtrealm = "https://tratcheroutlook.onmicrosoft.com/AspNetCoreSample",
                 MetadataAddress = "https://login.windows.net/cdc690f9-b6b8-4023-813a-bae7143d1f87/FederationMetadata/2007-06/FederationMetadata.xml",
             });
-            */
 
             app.UseOpenIdConnectAuthentication(new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions()
             {

--- a/tests/Katana.Sandbox.WebServer/Web.config
+++ b/tests/Katana.Sandbox.WebServer/Web.config
@@ -55,7 +55,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/Katana.Sandbox.WebServer/packages.config
+++ b/tests/Katana.Sandbox.WebServer/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
 </packages>

--- a/tests/Microsoft.Owin.Security.Tests/JwtHandlerTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/JwtHandlerTests.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens;
-using System.Security.Claims;
-using System.Security.Cryptography;
-using System.ServiceModel.Security.Tokens;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.Jwt;
 using Shouldly;
 using Xunit;
@@ -18,8 +15,8 @@ namespace Microsoft.Owin.Security.Tests
         [Fact]
         public void HandlerConstructorShouldThrowWhenAnAllowedAudienceIsNotSpecified()
         {
-            Should.Throw<ArgumentNullException>(() => new JwtFormat((string)null, (IIssuerSecurityTokenProvider)null));
-            Should.Throw<ArgumentNullException>(() => new JwtFormat((TokenValidationParameters)null, (IIssuerSecurityTokenProvider)null));
+            Should.Throw<ArgumentNullException>(() => new JwtFormat((string)null, (IIssuerSecurityKeyProvider)null));
+            Should.Throw<ArgumentNullException>(() => new JwtFormat((TokenValidationParameters)null, (IIssuerSecurityKeyProvider)null));
         }
 
         [Fact]
@@ -43,13 +40,13 @@ namespace Microsoft.Owin.Security.Tests
         [Fact]
         public void HandlerConstructorShouldThrowWhenTheIssuerSecurityTokenProviderEnumerableIsEmpty()
         {
-            Should.Throw<ArgumentOutOfRangeException>(() => new JwtFormat(new[] { "urn:issuer" }, new List<IIssuerSecurityTokenProvider>()));
+            Should.Throw<ArgumentOutOfRangeException>(() => new JwtFormat(new[] { "urn:issuer" }, new List<IIssuerSecurityKeyProvider>()));
         }
 
         [Fact]
         public void HandlerConstructorShouldNotThrowWithValidValues()
         {
-            var instance = new JwtFormat("http://audience/", new TestIssuerSecurityTokenProvider("urn:issuer"));
+            var instance = new JwtFormat("http://audience/", new TestIssuerSecurityKeyProvider("urn:issuer"));
 
             instance.ShouldNotBe(null);
         }
@@ -57,23 +54,23 @@ namespace Microsoft.Owin.Security.Tests
         [Fact]
         public void ProtectShouldThrowNotImplementedException()
         {
-            var instance = new JwtFormat("http://contoso.com", new TestIssuerSecurityTokenProvider("urn:issuer"));
+            var instance = new JwtFormat("http://contoso.com", new TestIssuerSecurityKeyProvider("urn:issuer"));
 
             Should.Throw<NotSupportedException>(() => instance.Protect(null));
         }
 
-        private class TestIssuerSecurityTokenProvider : IIssuerSecurityTokenProvider
+        private class TestIssuerSecurityKeyProvider : IIssuerSecurityKeyProvider
         {
-            public TestIssuerSecurityTokenProvider(string issuer)
+            public TestIssuerSecurityKeyProvider(string issuer)
             {
                 Issuer = issuer;
             }
 
             public virtual string Issuer { get; private set; }
 
-            public virtual IEnumerable<SecurityToken> SecurityTokens
+            public virtual IEnumerable<SecurityKey> SecurityKeys
             {
-                get { return new SecurityToken[0]; }
+                get { return new SecurityKey[0]; }
             }
         }
     }

--- a/tests/Microsoft.Owin.Security.Tests/Microsoft.Owin.Security.Tests.csproj
+++ b/tests/Microsoft.Owin.Security.Tests/Microsoft.Owin.Security.Tests.csproj
@@ -34,9 +34,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.2.0.407281058-pre\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -49,10 +57,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.0.407281058-pre\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />

--- a/tests/Microsoft.Owin.Security.Tests/packages.config
+++ b/tests/Microsoft.Owin.Security.Tests/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.0.407281058-pre" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.0.407281058-pre" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
#7 Do not merge.
This is an experiment on what it would take to update Katana to IdetityModel v5. I only did OpenIdConnect for now.

Other packages that need updating:
- Security.WsFederation - Missing IdentityModel dependencies
- Security.Jwt - Metadata retrieval needs refactoring, and our only implementations are for WsFed.
- Security.ActiveDirectory - Depends on WsFed and Security.Jwt

Q:
1. Are these the right changes to make for OIDC?
2. Should we check this in and ship alpha1 without the other three? Or ship alpha1 without it? Or just wait?