### PR TITLE
Remove extra ampersand from appsecret_proof.

### DIFF
--- a/build/Sakefile.shade
+++ b/build/Sakefile.shade
@@ -10,7 +10,7 @@ var AZUREAD_EXT_SUFFIX=''
 var VERSION='${SHIP.VERSION}'
 var FULL_VERSION='${SHIP.FULL_VERSION}'
 var EULA='https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm'
-var PROJECT_URL='http://katanaproject.codeplex.com/'
+var PROJECT_URL='https://github.com/aspnet/AspNetKatana/'
 var TAGS='Microsoft OWIN Katana'
 
 var BASE_DIR='${Directory.GetCurrentDirectory()}'

--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationHandler.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Owin.Security.Facebook
                 string graphAddress = WebUtilities.AddQueryString(Options.UserInformationEndpoint, "access_token", accessToken);
                 if (Options.SendAppSecretProof)
                 {
-                    graphAddress = WebUtilities.AddQueryString(graphAddress, "&appsecret_proof", GenerateAppSecretProof(accessToken));
+                    graphAddress = WebUtilities.AddQueryString(graphAddress, "appsecret_proof", GenerateAppSecretProof(accessToken));
                 }
                 if (Options.Fields.Count > 0)
                 {

--- a/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationHandler.cs
@@ -195,7 +195,9 @@ namespace Microsoft.Owin.Security.Google
 
                 AddQueryString(queryStrings, properties, "access_type", Options.AccessType);
                 AddQueryString(queryStrings, properties, "approval_prompt");
+                AddQueryString(queryStrings, properties, "prompt");
                 AddQueryString(queryStrings, properties, "login_hint");
+                AddQueryString(queryStrings, properties, "include_granted_scopes");
 
                 string state = Options.StateDataFormat.Protect(properties);
                 queryStrings.Add("state", state);

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -214,7 +214,10 @@ namespace Katana.Sandbox.WebServer
             {
                 map.Run(context =>
                 {
-                    context.Authentication.Challenge(new AuthenticationProperties() { RedirectUri = "/" }, context.Request.Query["scheme"]);
+                    var properties = new AuthenticationProperties();
+                    properties.RedirectUri = "/"; // Go back to the home page after authenticating.
+                    properties.Dictionary["prompt"] = "select_account"; // Google
+                    context.Authentication.Challenge(properties, context.Request.Query["scheme"]);
                     return Task.FromResult(0);
                 });
             });

--- a/tests/Microsoft.Owin.Security.Tests/Google/GoogleOAuth2MiddlewareTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/Google/GoogleOAuth2MiddlewareTests.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Owin.Security.Tests.Google
 
             location.ShouldNotContain("access_type=");
             location.ShouldNotContain("approval_prompt=");
+            location.ShouldNotContain("prompt=");
             location.ShouldNotContain("login_hint=");
+            location.ShouldNotContain("include_granted_scopes=");
         }
 
         [Fact]
@@ -162,7 +164,9 @@ namespace Microsoft.Owin.Security.Tests.Google
                                 { "scope", "https://www.googleapis.com/auth/plus.login" },
                                 { "access_type", "offline" },
                                 { "approval_prompt", "force" },
-                                { "login_hint", "test@example.com" }
+                                { "prompt", "consent" },
+                                { "login_hint", "test@example.com" },
+                                { "include_granted_scopes", "true" }
                             }), "Google");
                         res.StatusCode = 401;
                     }
@@ -175,7 +179,9 @@ namespace Microsoft.Owin.Security.Tests.Google
             query.ShouldContain("scope=" + Uri.EscapeDataString("https://www.googleapis.com/auth/plus.login"));
             query.ShouldContain("access_type=offline");
             query.ShouldContain("approval_prompt=force");
+            query.ShouldContain("prompt=consent");
             query.ShouldContain("login_hint=" + Uri.EscapeDataString("test@example.com"));
+            query.ShouldContain("include_granted_scopes=true");
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/aspnet/AspNetKatana/issues/38#issuecomment-291015826
When backporting the changes for the Facebook handler I left an extra `&` in the query string for the appsecret_proof param, which ends up getting escaped as `%26`. If you select `Require App Secret` in the Facebook app portal then it rejects requests with this extra encoded character. Note SendAppSecretProof is enabled by default, but Facebook does not validate it by default.
/cc: @erikarenhill @YovavGad 