### PR TITLE
Add standard OpenID Connect parameters

### DIFF
--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -150,6 +150,18 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                     Scope = Options.Scope,
                     State = OpenIdConnectAuthenticationDefaults.AuthenticationPropertiesKey + "=" + Uri.EscapeDataString(Options.StateDataFormat.Protect(properties)),
                 };
+                if (properties.Dictionary.ContainsKey("display"))
+                {
+                    openIdConnectMessage.Display = properties.Dictionary["display"];
+                }
+                if (properties.Dictionary.ContainsKey("login_hint"))
+                {
+                    openIdConnectMessage.LoginHint = properties.Dictionary["login_hint"];
+                }
+                if (properties.Dictionary.ContainsKey("prompt"))
+                {
+                    openIdConnectMessage.Prompt = properties.Dictionary["prompt"];
+                }
 
                 if (Options.ProtocolValidator.RequireNonce)
                 {


### PR DESCRIPTION
This tweak adds the display, login_hint, and prompt parameters as possible extra parameters to the authentication challenge. This way, you can specify an email address as the default login hint, and you can tell the identity provider to pause for confirmation instead of just logging straight in.