### PR TITLE
Fix MicrosoftAccount email claim mapping

### DIFF
--- a/src/Microsoft.Owin.Security.MicrosoftAccount/Provider/MicrosoftAccountAuthenticatedContext.cs
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/Provider/MicrosoftAccountAuthenticatedContext.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
             FirstName = PropertyValueIfExists("givenName", userAsDictionary);
             LastName = PropertyValueIfExists("surname", userAsDictionary);
             Email = PropertyValueIfExists("mail", userAsDictionary);
-            if (Email == null)
+            if (string.IsNullOrEmpty(Email))
             {
                 Email = PropertyValueIfExists("userPrincipalName", userAsDictionary);
             }


### PR DESCRIPTION
#446 This broke in 3.1 due to a subtle null vs empty issue for the new MSA provider.