### PR TITLE
Set LangVersion to restrict C# features.

### DIFF
--- a/build/Common.targets
+++ b/build/Common.targets
@@ -6,6 +6,7 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <PropertyGroup>
+    <LangVersion>5</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
#59 katana uses some old static analysis tools that do not understand C#6. This has lead to CI failures in the past. This change prevents C#6 from compiling in VS.