### PR TITLE
Prevent NullReferenceException when identities are rejected and renewed

### DIFF
--- a/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationHandler.cs
@@ -105,6 +105,13 @@ namespace Microsoft.Owin.Security.Cookies
 
                 await Options.Provider.ValidateIdentity(context);
 
+                if (context.Identity == null)
+                {
+                    // Rejected
+                    _shouldRenew = false;
+                    return null;
+                }
+
                 return new AuthenticationTicket(context.Identity, context.Properties);
             }
             catch (Exception exception)


### PR DESCRIPTION
#58 @AntonStokoz

Rejected identities would still end up creating an AuthTicket without a principal. If a sliding refresh was attempted on the same request then it would NRE on the missing principal.

The same code in ASP.NET Core has already been refactored so this should not be an issue there.