### PR TITLE
Don't dispose cancelled cancellation tokens

### DIFF
--- a/src/Microsoft.Owin.Host.HttpListener/DisconnectHandler.cs
+++ b/src/Microsoft.Owin.Host.HttpListener/DisconnectHandler.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Owin.Host.HttpListener
                 _connectionCancellationTokens.TryRemove(connectionId, out cancellation);
                 LogHelper.LogException(_logger, "HttpWaitForDisconnectEx", new Win32Exception((int)hr));
                 cts.Cancel();
-                cts.Dispose();
             }
 
             return returnToken;
@@ -129,7 +128,6 @@ namespace Microsoft.Owin.Host.HttpListener
             {
                 LogHelper.LogException(_logger, "App errors on disconnect notification.", age);
             }
-            cts.Dispose();
         }
 
         private class ConnectionCancellation


### PR DESCRIPTION
#108 
Disposed tokens cause ObjectDisposedExceptions when you try to register with them. Cancelled tokens immediately invoke your callback. If you cancel and dispose a token then there's a race where you may get a callback or an ODE. Disposal is only required for tokens that won't be cancelled, as cancellation does all of the same cleanup.

We did this for ASP.NET Core, we should backport it. Compare: 
https://github.com/aspnet/AspNetKatana/blob/5d58dab237663b694515a3adbb36dd246a7d4ca2/src/Microsoft.Owin.Host.HttpListener/DisconnectHandler.cs#L114-L132
https://github.com/aspnet/HttpSysServer/blob/dev/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/DisconnectListener.cs#L82-L120