### PR TITLE
Include facebook scopes and fields by default

### DIFF
--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Owin.Security.Facebook
     /// </summary>
     public class FacebookAuthenticationOptions : AuthenticationOptions
     {
-        private IList<string> _fields;
+        private ICollection<string> _fields;
 
         /// <summary>
         /// Initializes a new <see cref="FacebookAuthenticationOptions"/>
@@ -30,12 +30,19 @@ namespace Microsoft.Owin.Security.Facebook
             Scope = new List<string>();
             BackchannelTimeout = TimeSpan.FromSeconds(60);
             SendAppSecretProof = true;
-            _fields = new List<string>();
+            _fields = new HashSet<string>();
             CookieManager = new CookieManager();
 
             AuthorizationEndpoint = Constants.AuthorizationEndpoint;
             TokenEndpoint = Constants.TokenEndpoint;
             UserInformationEndpoint = Constants.UserInformationEndpoint;
+
+            Scope.Add("public_profile");
+            Scope.Add("email");
+            Fields.Add("name");
+            Fields.Add("email");
+            Fields.Add("first_name");
+            Fields.Add("last_name");
         }
 
         /// <summary>
@@ -135,7 +142,7 @@ namespace Microsoft.Owin.Security.Facebook
         /// The list of fields to retrieve from the UserInformationEndpoint.
         /// https://developers.facebook.com/docs/graph-api/reference/user
         /// </summary>
-        public IList<string> Fields
+        public ICollection<string> Fields
         {
             get { return _fields; }
         }

--- a/tests/FunctionalTests/Facts/Security/Facebook/FacebookAuthentication.cs
+++ b/tests/FunctionalTests/Facts/Security/Facebook/FacebookAuthentication.cs
@@ -40,7 +40,7 @@ namespace FunctionalTests.Facts.Security.Facebook
                 Assert.Equal<string>("code", queryItems["response_type"]);
                 Assert.Equal<string>("550624398330273", queryItems["client_id"]);
                 Assert.Equal<string>(applicationUrl + "signin-facebook", queryItems["redirect_uri"]);
-                Assert.Equal<string>("email,read_friendlists,user_checkins", queryItems["scope"]);
+                Assert.Equal<string>("public_profile,email,read_friendlists,user_checkins", queryItems["scope"]);
                 Assert.Equal<string>("ValidStateData", queryItems["state"]);
                 Assert.Equal<string>("custom", queryItems["custom_redirect_uri"]);
 
@@ -166,7 +166,6 @@ namespace FunctionalTests.Facts.Security.Facebook
                 StateDataFormat = new CustomStateDataFormat()
             };
 
-            option.Scope.Add("email");
             option.Scope.Add("read_friendlists");
             option.Scope.Add("user_checkins");
 

--- a/tests/FunctionalTests/Facts/Security/Twitter/TwitterAuthentication.cs
+++ b/tests/FunctionalTests/Facts/Security/Twitter/TwitterAuthentication.cs
@@ -40,7 +40,7 @@ namespace FunctionalTests.Facts.Security.Twitter
 
                 // Unauthenticated request - verify Redirect url
                 var response = await httpClient.GetAsync(applicationUrl);
-                Assert.Equal<string>("https://twitter.com/oauth/authenticate", response.Headers.Location.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));
+                Assert.Equal<string>("https://api.twitter.com/oauth/authenticate", response.Headers.Location.AbsoluteUri.Replace(response.Headers.Location.Query, string.Empty));
                 var queryItems = response.Headers.Location.ParseQueryString();
                 Assert.Equal<string>("custom", queryItems["custom_redirect_uri"]);
                 Assert.NotNull(queryItems["oauth_token"]);


### PR DESCRIPTION
#113 This is a backport of https://github.com/aspnet/Security/commit/e737f3207e8ceb80f6bcf1286b4ea0fec9ea72ea#diff-4621d8e36c62a3665d8427d0db85baa9.
https://github.com/aspnet/Security/blob/bd8ecd02684d490ece96c484e1092386f3515dec/src/Microsoft.AspNetCore.Authentication.Facebook/FacebookOptions.cs#L29-L34
It fixes a regression after we reacted to the Facebook API changes in 3.1 where facebook started requiring a scope and field added to the auth process to get e-mail addresses.

Note the change of Fields to a HashSet is needed because Facebook fails requests with duplicate field values and users may already be adding this field in their app. Facebook does not require unique Scope values, so we'll leave that one alone here.