### PR TITLE
Parse long ranges

### DIFF
--- a/src/Microsoft.Owin.StaticFiles/Infrastructure/RangeHelpers.cs
+++ b/src/Microsoft.Owin.StaticFiles/Infrastructure/RangeHelpers.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Owin.StaticFiles.Infrastructure
 
         private static bool TryParseLong(string input, out long? result)
         {
-            int temp;
+            long temp;
             if (!string.IsNullOrWhiteSpace(input)
-                && int.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out temp))
+                && long.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out temp))
             {
                 result = temp;
                 return true;

--- a/tests/Microsoft.Owin.StaticFiles.Tests/RangeHeaderTests.cs
+++ b/tests/Microsoft.Owin.StaticFiles.Tests/RangeHeaderTests.cs
@@ -226,6 +226,8 @@ namespace Microsoft.Owin.StaticFiles.Tests
         [InlineData("-26", "36-61", 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")] // Last 26
         [InlineData("0-", "0-61", 62, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]
         [InlineData("-1001", "0-61", 62, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]
+        [InlineData("-123456789123", "0-61", 62, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]
+        [InlineData("36-123456789123", "36-61", 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")]
         public async Task SingleValidRangeShouldServePartialContent(string range, string expectedRange, int length, string expectedData)
         {
             TestServer server = TestServer.Create(app => app.UseFileServer());


### PR DESCRIPTION
 #158. Not sure why this was using ints. This was re-written in Core.