### PR TITLE
Handle early disconnects 

### DIFF
--- a/src/Microsoft.Owin.Host.HttpListener/DisconnectHandler.cs
+++ b/src/Microsoft.Owin.Host.HttpListener/DisconnectHandler.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Owin.Host.HttpListener
 
     internal class DisconnectHandler
     {
+        // Win8 minimum
+        private static bool SkipIOCPCallbackOnSuccess = Environment.OSVersion.Version >= new Version(6, 2);
+
         private readonly ConcurrentDictionary<ulong, ConnectionCancellation> _connectionCancellationTokens;
         private readonly System.Net.HttpListener _listener;
         private readonly CriticalHandle _requestQueueHandle;
@@ -111,6 +114,15 @@ namespace Microsoft.Owin.Host.HttpListener
                 ConnectionCancellation cancellation;
                 _connectionCancellationTokens.TryRemove(connectionId, out cancellation);
                 LogHelper.LogException(_logger, "HttpWaitForDisconnectEx", new Win32Exception((int)hr));
+                cts.Cancel();
+            }
+
+            if (hr == NativeMethods.HttpErrors.NO_ERROR && SkipIOCPCallbackOnSuccess)
+            {
+                // IO operation completed synchronously - callback won't be called to signal completion
+                Overlapped.Free(nativeOverlapped);
+                ConnectionCancellation cancellation;
+                _connectionCancellationTokens.TryRemove(connectionId, out cancellation);
                 cts.Cancel();
             }
 


### PR DESCRIPTION
#141 This is a backport of a fix from Core:
https://github.com/aspnet/HttpSysServer/blob/4c388e89ce453a189aa861a40297a576aed14cdd/src/Microsoft.AspNetCore.Server.HttpSys/NativeInterop/DisconnectListener.cs#L114-L121

On Win8+ if async operations complete sync, such as the client already being disconnected, then we need to handle the async completion inline.

Verified using the manual repro code from the issue.

@maxcherednik 