### PR TITLE
Stop NullReferenceException when TestServer is created using protecte…

### DIFF
--- a/src/Microsoft.Owin.Testing/TestServer.cs
+++ b/src/Microsoft.Owin.Testing/TestServer.cs
@@ -187,7 +187,10 @@ namespace Microsoft.Owin.Testing
         protected virtual void Dispose(bool disposing)
         {
             _disposed = true;
-            _started.Dispose();
+            if (_started != null)
+            {
+                _started.Dispose();
+            }
         }
 
         private class TestServerFactory


### PR DESCRIPTION
…d constructor

I had an issue with the built in IoC container of Specflow. TestServer was a constructor parameter for a test class and the IoC container would instantiate TestServer, but using the protected constructor. At the end of each scenario, Dispose() would be called on TestServer and a NullReferenceException would be thrown when calling _started.Dispose() as this object was never instantiated via the Create() method.