### PR TITLE
add exception handler for NotSupportedException

### DIFF
--- a/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
+++ b/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
@@ -81,10 +81,17 @@ namespace Microsoft.Owin.FileSystems
                 }
                 return fullPath;
             }
+            catch (ArgumentException)
+            {
+            }
             catch (NotSupportedException)
             {
-                return null;
             }
+            catch (PathTooLongException)
+            {
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
+++ b/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
@@ -81,17 +81,10 @@ namespace Microsoft.Owin.FileSystems
                 }
                 return fullPath;
             }
-            catch (ArgumentException)
+            catch
             {
+                return null;
             }
-            catch (NotSupportedException)
-            {
-            }
-            catch (PathTooLongException)
-            {
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
+++ b/src/Microsoft.Owin.FileSystems/PhysicalFileSystem.cs
@@ -72,12 +72,19 @@ namespace Microsoft.Owin.FileSystems
 
         private string GetFullPath(string path)
         {
-            var fullPath = Path.GetFullPath(Path.Combine(Root, path));
-            if (!fullPath.StartsWith(Root, StringComparison.OrdinalIgnoreCase))
+            try
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(Root, path));
+                if (!fullPath.StartsWith(Root, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+                return fullPath;
+            }
+            catch (NotSupportedException)
             {
                 return null;
             }
-            return fullPath;
         }
 
         /// <summary>

--- a/tests/Microsoft.Owin.FileSystems.Tests/PhysicalFileSystemTests.cs
+++ b/tests/Microsoft.Owin.FileSystems.Tests/PhysicalFileSystemTests.cs
@@ -59,5 +59,14 @@ namespace Microsoft.Owin.FileSystems.Tests
             info.ShouldNotBe(null);
             info.PhysicalPath.ShouldBe(file2);
         }
+
+        [Fact]
+        public void NotSupportedCharactersInPathReturnFalse()
+        {
+            var provider = new PhysicalFileSystem("sub");
+            IFileInfo info;
+            provider.TryGetFileInfo("(DefaultRouterOutlet:type)", out info).ShouldBe(false);
+            info.ShouldBe(null);
+        }
     }
 }


### PR DESCRIPTION
requests like "http://<server>/entity/**(**DefaultRouterOutlet:type**)**" throw on a windows system a NotSupportedException when the PhysicalFileSystem.TryGetFileInfo or PhysicalFileSystem.TryGetDirectoryContents is called. This results in a 500 instead of a 404. 

Catching this exception will prevent this issue.