### PR TITLE
CookieValidateIdentityContext.ReplaceIdentity keep ClaimsIdentity instance

### DIFF
--- a/src/Microsoft.Owin.Security.Cookies/Provider/CookieValidateIdentityContext.cs
+++ b/src/Microsoft.Owin.Security.Cookies/Provider/CookieValidateIdentityContext.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Owin.Security.Cookies
         /// <param name="identity">The identity used as the replacement</param>
         public void ReplaceIdentity(IIdentity identity)
         {
-            Identity = new ClaimsIdentity(identity);
+            Identity = identity as ClaimsIdentity ?? new ClaimsIdentity(identity);
         }
 
         /// <summary>

--- a/tests/Microsoft.Owin.Security.Tests/Cookies/CookieMiddlewareTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/Cookies/CookieMiddlewareTests.cs
@@ -530,6 +530,32 @@ namespace Microsoft.Owin.Security.Tests
             responded.Single().ShouldContain("\"location\"");
         }
 
+        [Fact]
+        public void CookieReplaceIdentityWithClaimsIdentity()
+        {
+            var ticket = new AuthenticationTicket(null, null);
+            var context = new CookieValidateIdentityContext(null, ticket, null);
+            var newIdentity = new TestClaimsIdentityDerived();
+
+            context.ReplaceIdentity(newIdentity);
+
+            Assert.IsType<TestClaimsIdentityDerived>(context.Identity);
+            Assert.Same(newIdentity, context.Identity);
+        }
+
+        [Fact]
+        public void CookieReplaceIdentityWithNonClaimsIdentity()
+        {
+            var ticket = new AuthenticationTicket(null, null);
+            var context = new CookieValidateIdentityContext(null, ticket, null);
+            var newIdentity = new TestNonClaimsIdentity();
+
+            context.ReplaceIdentity(newIdentity);
+
+            Assert.IsType<ClaimsIdentity>(context.Identity);
+            Assert.NotSame(newIdentity, context.Identity);
+        }
+
         private static string FindClaimValue(Transaction transaction, string claimType)
         {
             XElement claim = transaction.ResponseElement.Elements("claim").SingleOrDefault(elt => elt.Attribute("type").Value == claimType);
@@ -698,5 +724,20 @@ namespace Microsoft.Owin.Security.Tests
                 return Task.FromResult(key);
             }
         }
+
+        private class TestNonClaimsIdentity : IIdentity
+        {
+            public string Name { get { return "NonClaimsIdentity"; } }
+
+            public string AuthenticationType { get { return string.Empty; } }
+
+            public bool IsAuthenticated { get { return false; } }
+        }
+
+        private class TestClaimsIdentityDerived : ClaimsIdentity
+        {
+        }
+
     }
+
 }


### PR DESCRIPTION
- `CookieValidateIdentityContext.ReplaceIdentity()` previously always created a
new `ClaimsIdentity` instance from the passed `IIdentity`.  This prevents
the application from storing a `ClaimsIdentity`-derived  instance.
 - Now `ReplaceIdentity()` will store the identity parameter as-is if it is
of type `ClaimsIdentity`, otherwise, creating a new `ClaimsIdentity` from
the identity parameter.

Addresses #194