### PR TITLE
Add missing package copyright

### DIFF
--- a/src/Microsoft.Owin.Cors/Microsoft.Owin.Cors.nuspec
+++ b/src/Microsoft.Owin.Cors/Microsoft.Owin.Cors.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Diagnostics/Microsoft.Owin.Diagnostics.nuspec
+++ b/src/Microsoft.Owin.Diagnostics/Microsoft.Owin.Diagnostics.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.FileSystems/Microsoft.Owin.FileSystems.nuspec
+++ b/src/Microsoft.Owin.FileSystems/Microsoft.Owin.FileSystems.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Host.HttpListener/Microsoft.Owin.Host.HttpListener.nuspec
+++ b/src/Microsoft.Owin.Host.HttpListener/Microsoft.Owin.Host.HttpListener.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Host.SystemWeb/Microsoft.Owin.Host.SystemWeb.nuspec
+++ b/src/Microsoft.Owin.Host.SystemWeb/Microsoft.Owin.Host.SystemWeb.nuspec
@@ -4,6 +4,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Hosting/Microsoft.Owin.Hosting.nuspec
+++ b/src/Microsoft.Owin.Hosting/Microsoft.Owin.Hosting.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.nuspec
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/Microsoft.Owin.Security.ActiveDirectory.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.Cookies/Microsoft.Owin.Security.Cookies.nuspec
+++ b/src/Microsoft.Owin.Security.Cookies/Microsoft.Owin.Security.Cookies.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.nuspec
+++ b/src/Microsoft.Owin.Security.Facebook/Microsoft.Owin.Security.Facebook.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.nuspec
+++ b/src/Microsoft.Owin.Security.Google/Microsoft.Owin.Security.Google.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.nuspec
+++ b/src/Microsoft.Owin.Security.Jwt/Microsoft.Owin.Security.Jwt.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.nuspec
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/Microsoft.Owin.Security.MicrosoftAccount.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.nuspec
+++ b/src/Microsoft.Owin.Security.OAuth/Microsoft.Owin.Security.OAuth.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.nuspec
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.nuspec
+++ b/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.nuspec
+++ b/src/Microsoft.Owin.Security.WsFederation/Microsoft.Owin.Security.WsFederation.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Security/Microsoft.Owin.Security.nuspec
+++ b/src/Microsoft.Owin.Security/Microsoft.Owin.Security.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.SelfHost/Microsoft.Owin.SelfHost.nuspec
+++ b/src/Microsoft.Owin.SelfHost/Microsoft.Owin.SelfHost.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.StaticFiles/Microsoft.Owin.StaticFiles.nuspec
+++ b/src/Microsoft.Owin.StaticFiles/Microsoft.Owin.StaticFiles.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin.Testing/Microsoft.Owin.Testing.nuspec
+++ b/src/Microsoft.Owin.Testing/Microsoft.Owin.Testing.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/Microsoft.Owin/Microsoft.Owin.nuspec
+++ b/src/Microsoft.Owin/Microsoft.Owin.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/src/OwinHost/OwinHost.nuspec
+++ b/src/OwinHost/OwinHost.nuspec
@@ -5,6 +5,7 @@
     <version>$version$</version>
     <authors>$authors$</authors>
     <owners>$authors$</owners>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>$licenseUrl$</licenseUrl>
     <projectUrl>$projectUrl$</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
 #233 copyright was the only rule failing for for the main packages. I'll follow up for the loc satellite packages.