### PR TITLE
more robust way to configure Cache-Control for the auth apis

### DIFF
--- a/src/Microsoft.Owin.Security.OAuth/OAuthAuthorizationServerHandler.cs
+++ b/src/Microsoft.Owin.Security.OAuth/OAuthAuthorizationServerHandler.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Owin.Security.OAuth
                 body = memory.ToArray();
             }
             Response.ContentType = "application/json;charset=UTF-8";
-            Response.Headers.Set("Cache-Control", "no-cache");
+            Response.Headers.Set("Cache-Control", "private, no-cache, no-store, max-age=0");
             Response.Headers.Set("Pragma", "no-cache");
             Response.Headers.Set("Expires", "-1");
             Response.ContentLength = body.Length;


### PR DESCRIPTION
The Cache-Control: no-cache is not enough to tell all the clients and the proxies not to cache the auth api responses. See below for the detailed explanation:
<snip>
Cache-Control

This is probably the most important header when it comes to security. There are a number of options associated with this header. Most importantly, the page can be marked as "private" or "public". A proxy will not cache a page if it is marked as "private". Other options are sometimes used inappropriately. For example the "no-cache" option just implies that the proxy should verify each time the page is requested if the page is still valid, but it may still store the page. A better option to add is "no-store" which will prevent request and response from being stored by the cache. The "no-transform" option may be important for mobile users. Some mobile providers will compress or alter content, in particular images, to save bandwidth when re-transmitting content over cellular networks. This could break digital signatures in some cases. "no-transform" will prevent that (but again: doesn't matter for SSL. Only if you rely on digital signatures transmitted to verify an image for example).The "max-age" option can be used to indicate how long a response can be cached. Setting it to "0" will prevent caching.

A "safe" Cache-Control header would be:

Cache-Control: private, no-cache, no-store, max-age=0
</snip>
Reference:
https://isc.sans.edu/forums/diary/The+Security+Impact+of+HTTP+Caching+Headers/17033/