### PR TITLE
Enable ability to force redirect_uri to be https only

### DIFF
--- a/src/Microsoft.Owin.Security.Facebook/Constants.cs
+++ b/src/Microsoft.Owin.Security.Facebook/Constants.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Owin.Security.Facebook
     {
         public const string DefaultAuthenticationType = "Facebook";
 
-        internal const string AuthorizationEndpoint = "https://www.facebook.com/v2.8/dialog/oauth";
-        internal const string TokenEndpoint = "https://graph.facebook.com/v2.8/oauth/access_token";
-        internal const string UserInformationEndpoint = "https://graph.facebook.com/v2.8/me";
+        internal const string AuthorizationEndpoint = "https://www.facebook.com/dialog/oauth";
+        internal const string TokenEndpoint = "https://graph.facebook.com/oauth/access_token";
+        internal const string UserInformationEndpoint = "https://graph.facebook.com/me";
     }
 }

--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationHandler.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Owin.Security.Facebook
     internal class FacebookAuthenticationHandler : AuthenticationHandler<FacebookAuthenticationOptions>
     {
         private const string XmlSchemaString = "http://www.w3.org/2001/XMLSchema#string";
+        private const string HttpSecure = "https";
 
         private readonly ILogger _logger;
         private readonly HttpClient _httpClient;
@@ -76,7 +77,7 @@ namespace Microsoft.Owin.Security.Facebook
                     return new AuthenticationTicket(null, properties);
                 }
 
-                string requestPrefix = Request.Scheme + "://" + Request.Host;
+                string requestPrefix = GetScheme() + "://" + Request.Host;
                 string redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
 
                 string tokenRequest = "grant_type=authorization_code" +
@@ -169,8 +170,8 @@ namespace Microsoft.Owin.Security.Facebook
 
             if (challenge != null)
             {
-                string baseUri = 
-                    Request.Scheme + 
+                string baseUri =
+                    GetScheme() + 
                     Uri.SchemeDelimiter + 
                     Request.Host +
                     Request.PathBase;
@@ -280,6 +281,11 @@ namespace Microsoft.Owin.Security.Facebook
                 }
                 return builder.ToString();
             }
+        }
+
+        private string GetScheme()
+        {
+            return Options.ForceSecureRedirect ? HttpSecure : Request.Scheme;
         }
     }
 }

--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationOptions.cs
@@ -151,5 +151,10 @@ namespace Microsoft.Owin.Security.Facebook
         /// An abstraction for reading and setting cookies during the authentication process.
         /// </summary>
         public ICookieManager CookieManager { get; set; }
+
+        /// <summary>
+        /// Gets or set whether to override request scheme to force secure redirect (https) from OAuth callback.
+        /// </summary>
+        public bool ForceSecureRedirect { get; set; }
     }
 }


### PR DESCRIPTION
We were encountering issues between load balancer/server due to being http between them for oAuth redirect for facebook.

Facebook has been enabled to generally accept only https urls for redirects for security reasons so this is tightening that up.

Also updated constant API values used to point at non-deprecated urls.