### PR TITLE
Facebook OAuth Urls updated due to soon limited lifetime

### DIFF
--- a/src/Microsoft.Owin.Security.Facebook/Constants.cs
+++ b/src/Microsoft.Owin.Security.Facebook/Constants.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Owin.Security.Facebook
     {
         public const string DefaultAuthenticationType = "Facebook";
 
-        internal const string AuthorizationEndpoint = "https://www.facebook.com/v2.8/dialog/oauth";
-        internal const string TokenEndpoint = "https://graph.facebook.com/v2.8/oauth/access_token";
-        internal const string UserInformationEndpoint = "https://graph.facebook.com/v2.8/me";
+        internal const string AuthorizationEndpoint = "https://www.facebook.com/dialog/oauth";
+        internal const string TokenEndpoint = "https://graph.facebook.com/oauth/access_token";
+        internal const string UserInformationEndpoint = "https://graph.facebook.com/me";
     }
 }


### PR DESCRIPTION
The graph API v2.8 will expire on 18th of April. Updating urls to point to latest version.

https://developers.facebook.com/docs/graph-api/changelog/ <- See available til.