### PR TITLE
Issue #278 DefaultLoader now prefilters attributes before instantiating

### DIFF
--- a/src/Owin.Loader/DefaultLoader.cs
+++ b/src/Owin.Loader/DefaultLoader.cs
@@ -186,17 +186,24 @@ namespace Owin.Loader
             Assembly matchedAssembly = null;
             foreach (var assembly in _referencedAssemblies)
             {
-                object[] attributes;
+                Attribute[] attributes;
                 try
                 {
-                    attributes = assembly.GetCustomAttributes(inherit: false);
+                    // checking attribute's name first and only then instantiating it
+                    // then we are filtering attributes by name second time as inheritors could be added by calling to GetCustomAttributes(type)
+                    attributes = assembly.GetCustomAttributesData()
+                        .Where(data => DoesTypeNameReferToStartupAttribute(data.AttributeType))
+                        .Select(data => data.AttributeType)
+                        .SelectMany(type => assembly.GetCustomAttributes(type))
+                        .Distinct()
+                        .ToArray();
                 }
                 catch (CustomAttributeFormatException)
                 {
                     continue;
                 }
-
-                foreach (var owinStartupAttribute in attributes.Where(attribute => attribute.GetType().Name.Equals(Constants.OwinStartupAttribute, StringComparison.Ordinal)))
+                
+                foreach (var owinStartupAttribute in attributes.Where(attribute => DoesTypeNameReferToStartupAttribute(attribute.GetType())))
                 {
                     Type attributeType = owinStartupAttribute.GetType();
                     foundAnyInstances = true;
@@ -264,6 +271,11 @@ namespace Owin.Loader
                 return null;
             }
             return fullMatch;
+        }
+        
+        private static bool DoesTypeNameReferToStartupAttribute(Type type)
+        {
+            return type.Name.Equals(Constants.OwinStartupAttribute, StringComparison.Ordinal);
         }
 
         // Search for any assemblies with a Startup or [AssemblyName].Startup class.

--- a/src/Owin.Loader/DefaultLoader.cs
+++ b/src/Owin.Loader/DefaultLoader.cs
@@ -192,7 +192,7 @@ namespace Owin.Loader
                     // checking attribute's name first and only then instantiating it
                     // then we are filtering attributes by name second time as inheritors could be added by calling to GetCustomAttributes(type)
                     attributes = assembly.GetCustomAttributesData()
-                        .Where(data => DoesTypeNameReferToStartupAttribute(data.AttributeType))
+                        .Where(data => MatchesStartupAttribute(data.AttributeType))
                         .Select(data => data.AttributeType)
                         .SelectMany(type => assembly.GetCustomAttributes(type))
                         .Distinct()
@@ -203,7 +203,7 @@ namespace Owin.Loader
                     continue;
                 }
                 
-                foreach (var owinStartupAttribute in attributes.Where(attribute => DoesTypeNameReferToStartupAttribute(attribute.GetType())))
+                foreach (var owinStartupAttribute in attributes.Where(attribute => MatchesStartupAttribute(attribute.GetType())))
                 {
                     Type attributeType = owinStartupAttribute.GetType();
                     foundAnyInstances = true;
@@ -273,7 +273,7 @@ namespace Owin.Loader
             return fullMatch;
         }
         
-        private static bool DoesTypeNameReferToStartupAttribute(Type type)
+        private static bool MatchesStartupAttribute(Type type)
         {
             return type.Name.Equals(Constants.OwinStartupAttribute, StringComparison.Ordinal);
         }


### PR DESCRIPTION
Assembly attributes will be instantiated only if same assembly contains any OwinStartup attribute(s)