### PR TITLE
SameSite attribute support for ResponseCookieCollection

### DIFF
--- a/src/Microsoft.Owin/CookieOptions.cs
+++ b/src/Microsoft.Owin/CookieOptions.cs
@@ -47,5 +47,12 @@ namespace Microsoft.Owin
         /// </summary>
         /// <returns>true if a cookie is accessible by client-side script; otherwise, false.</returns>
         public bool HttpOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates on which requests client should or should not send cookie back to the server.
+        /// Set to null to do not include SameSite attribute at all.
+        /// </summary>
+        /// <returns>SameSite attribute value or null if attribute must not be set.</returns>
+        public SameSiteMode? SameSite { get; set; }
     }
 }

--- a/src/Microsoft.Owin/Microsoft.Owin.csproj
+++ b/src/Microsoft.Owin/Microsoft.Owin.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Infrastructure\SystemClock.cs" />
     <Compile Include="Infrastructure\WebUtils.cs" />
     <Compile Include="ResponseCookieCollection.cs" />
+    <Compile Include="SameSiteMode.cs" />
     <Compile Include="Security\AuthenticateResult.cs" />
     <Compile Include="Security\AuthenticationDescription.cs" />
     <Compile Include="Extensions\IntegratedPipelineExtensions.cs" />

--- a/src/Microsoft.Owin/SameSiteMode.cs
+++ b/src/Microsoft.Owin/SameSiteMode.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.Owin
+{
+    /// <summary>
+    /// Indicates if the client should include a cookie on "same-site" or "cross-site" requests.
+    /// </summary>
+    public enum SameSiteMode
+    {
+        /// <summary>
+        /// Indicates the client should send the cookie with every requests coming from any origin.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Indicates the client should send the cookie with "same-site" requests, and with "cross-site" top-level navigations.
+        /// </summary>
+        Lax,
+        /// <summary>
+        /// Indicates the client should only send the cookie with "same-site" requests.
+        /// </summary>
+        Strict
+    }
+}


### PR DESCRIPTION
I have added a way to set SameSite attribute value for Set-Cookie headers.
You can do so by setting `CookieOptions.SameSite` property to some non null value.
If `CookieOptions.SameSite` property is null then SameSite attribute will not be added at all.

I must point out that if you use `SameSiteMode.None` it will be set as SameSite=None.

You can read about that behavior [here](https://web.dev/samesite-cookies-explained/) and [here](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1)