### PR TITLE
Use SameSite everywhere

### DIFF
--- a/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Owin.Host.SystemWeb
         internal static readonly bool IsSameSiteAvailable;
         internal static readonly MethodInfo SameSiteSetter;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static SystemWebCookieManager()
         {
             var systemWeb = typeof(HttpContextBase).Assembly;

--- a/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/SystemWebCookieManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Reflection;
 using System.Web;
 using Microsoft.Owin.Infrastructure;
 
@@ -12,6 +13,20 @@ namespace Microsoft.Owin.Host.SystemWeb
     /// </summary>
     public class SystemWebCookieManager : ICookieManager
     {
+        // .NET 4.7.2, but requries a patch to emit SameSite=None
+        internal static readonly bool IsSameSiteAvailable;
+        internal static readonly MethodInfo SameSiteSetter;
+
+        static SystemWebCookieManager()
+        {
+            var systemWeb = typeof(HttpContextBase).Assembly;
+            IsSameSiteAvailable = systemWeb.GetType("System.Web.SameSiteMode") != null;
+            if (IsSameSiteAvailable)
+            {
+                SameSiteSetter = typeof(HttpCookie).GetProperty("SameSite").SetMethod;
+            }
+        }
+
         /// <summary>
         /// Creates a new instance of SystemWebCookieManager.
         /// </summary>
@@ -104,6 +119,13 @@ namespace Microsoft.Owin.Host.SystemWeb
             {
                 cookie.HttpOnly = true;
             }
+            if (IsSameSiteAvailable)
+            {
+                SameSiteSetter.Invoke(cookie, new object[]
+                {
+                    options.SameSite ?? (SameSiteMode)(-1) // Unspecified
+                });
+            }
 
             webContext.Response.AppendCookie(cookie);
         }
@@ -133,6 +155,9 @@ namespace Microsoft.Owin.Host.SystemWeb
                 {
                     Path = options.Path,
                     Domain = options.Domain,
+                    HttpOnly = options.HttpOnly,
+                    Secure = options.Secure,
+                    SameSite = options.SameSite,
                     Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                 });
         }

--- a/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationHandler.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Owin.Security.Cookies
                 {
                     Domain = Options.CookieDomain,
                     HttpOnly = Options.CookieHttpOnly,
+                    SameSite = Options.CookieSameSite,
                     Path = Options.CookiePath ?? "/",
                 };
                 if (Options.CookieSecure == CookieSecureOption.SameAsRequest)

--- a/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.Cookies/CookieAuthenticationOptions.cs
@@ -66,6 +66,12 @@ namespace Microsoft.Owin.Security.Cookies
         public bool CookieHttpOnly { get; set; }
 
         /// <summary>
+        /// Determines if the browser should allow the cookie to be sent with requests initiated from other sites.
+        /// The default is 'null' to exclude the setting and let the browser choose the default behavior.
+        /// </summary>
+        public SameSiteMode? CookieSameSite { get; set; }
+
+        /// <summary>
         /// Determines if the cookie should only be transmitted on HTTPS request. The default is to limit the cookie
         /// to HTTPS requests if the page which is doing the SignIn is also HTTPS. If you have an HTTPS sign in page
         /// and portions of your site are HTTP you may need to change this value.

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -637,6 +637,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(Options.StateDataFormat.Protect(properties))),
                 new CookieOptions
                 {
+                    SameSite = SameSiteMode.None,
                     HttpOnly = true,
                     Secure = Request.IsSecure,
                     Expires = DateTime.UtcNow + Options.ProtocolValidator.NonceLifetime
@@ -667,6 +668,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
             {
                 var cookieOptions = new CookieOptions
                 {
+                    SameSite = SameSiteMode.None,
                     HttpOnly = true,
                     Secure = Request.IsSecure
                 };

--- a/src/Microsoft.Owin.Security/Infrastructure/AuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security/Infrastructure/AuthenticationHandler.cs
@@ -215,6 +215,7 @@ namespace Microsoft.Owin.Security.Infrastructure
 
             var cookieOptions = new CookieOptions
             {
+                SameSite = SameSiteMode.None,
                 HttpOnly = true,
                 Secure = Request.IsSecure
             };
@@ -243,6 +244,7 @@ namespace Microsoft.Owin.Security.Infrastructure
 
             var cookieOptions = new CookieOptions
             {
+                SameSite = SameSiteMode.None,
                 HttpOnly = true,
                 Secure = Request.IsSecure
             };
@@ -277,6 +279,7 @@ namespace Microsoft.Owin.Security.Infrastructure
 
             var cookieOptions = new CookieOptions
             {
+                SameSite = SameSiteMode.None,
                 HttpOnly = true,
                 Secure = Request.IsSecure
             };
@@ -332,6 +335,7 @@ namespace Microsoft.Owin.Security.Infrastructure
 
             var cookieOptions = new CookieOptions
             {
+                SameSite = SameSiteMode.None,
                 HttpOnly = true,
                 Secure = Request.IsSecure
             };

--- a/src/Microsoft.Owin/Infrastructure/ChunkingCookieManager.cs
+++ b/src/Microsoft.Owin/Infrastructure/ChunkingCookieManager.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Owin.Infrastructure
             bool domainHasValue = !string.IsNullOrEmpty(options.Domain);
             bool pathHasValue = !string.IsNullOrEmpty(options.Path);
             bool expiresHasValue = options.Expires.HasValue;
+            bool sameSiteHasValue = options.SameSite.HasValue;
 
             string escapedKey = Uri.EscapeDataString(key);
             string prefix = escapedKey + "=";
@@ -146,9 +147,11 @@ namespace Microsoft.Owin.Infrastructure
                 !pathHasValue ? null : "; path=",
                 !pathHasValue ? null : options.Path,
                 !expiresHasValue ? null : "; expires=",
-                !expiresHasValue ? null : options.Expires.Value.ToString("ddd, dd-MMM-yyyy HH:mm:ss ", CultureInfo.InvariantCulture) + "GMT",
+                !expiresHasValue ? null : options.Expires.Value.ToString("ddd, dd-MMM-yyyy HH:mm:ss \\G\\M\\T", CultureInfo.InvariantCulture),
                 !options.Secure ? null : "; secure",
-                !options.HttpOnly ? null : "; HttpOnly");
+                !options.HttpOnly ? null : "; HttpOnly",
+                !sameSiteHasValue ? null : "; SameSite=",
+                !sameSiteHasValue ? null : GetStringRepresentationOfSameSite(options.SameSite.Value));
 
             value = value ?? string.Empty;
             bool quoted = false;
@@ -277,6 +280,9 @@ namespace Microsoft.Owin.Infrastructure
                 {
                     Path = options.Path,
                     Domain = options.Domain,
+                    HttpOnly = options.HttpOnly,
+                    SameSite = options.SameSite,
+                    Secure = options.Secure,
                     Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                 });
 
@@ -290,6 +296,9 @@ namespace Microsoft.Owin.Infrastructure
                     {
                         Path = options.Path,
                         Domain = options.Domain,
+                        HttpOnly = options.HttpOnly,
+                        SameSite = options.SameSite,
+                        Secure = options.Secure,
                         Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                     });
             }
@@ -308,6 +317,22 @@ namespace Microsoft.Owin.Infrastructure
         private static string Quote(string value)
         {
             return '"' + value + '"';
+        }
+
+        private static string GetStringRepresentationOfSameSite(SameSiteMode siteMode)
+        {
+            switch (siteMode)
+            {
+                case SameSiteMode.None:
+                    return "None";
+                case SameSiteMode.Lax:
+                    return "Lax";
+                case SameSiteMode.Strict:
+                    return "Strict";
+                default:
+                    throw new ArgumentOutOfRangeException("siteMode",
+                        string.Format(CultureInfo.InvariantCulture, "Unexpected SameSiteMode value: {0}", siteMode));
+            }
         }
     }
 }

--- a/src/Microsoft.Owin/ResponseCookieCollection.cs
+++ b/src/Microsoft.Owin/ResponseCookieCollection.cs
@@ -138,14 +138,13 @@ namespace Microsoft.Owin
             {
                 Path = options.Path,
                 Domain = options.Domain,
+                HttpOnly = options.HttpOnly,
+                SameSite = options.SameSite,
+                Secure = options.Secure,
                 Expires = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             });
         }
 
-        /// <summary>
-        /// Analogous to ToString() but without boxing so
-        /// we can save a bit of memory.
-        /// </summary>
         private static string GetStringRepresentationOfSameSite(SameSiteMode siteMode)
         {
             switch (siteMode)

--- a/tests/Katana.Sandbox.WebServer/Katana.Sandbox.WebServer.csproj
+++ b/tests/Katana.Sandbox.WebServer/Katana.Sandbox.WebServer.csproj
@@ -101,6 +101,7 @@
     <Compile Include="AspNetAuthSessionStore.cs" />
     <Compile Include="InMemoryAuthSessionStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SameSiteCookieManager.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
+++ b/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+
+namespace Katana.Sandbox.WebServer
+{
+    public class SameSiteCookieManager : ICookieManager
+    {
+        private readonly ICookieManager _innerManager;
+
+        public SameSiteCookieManager()
+            : this(new CookieManager())
+        {   
+        }
+
+        public SameSiteCookieManager(ICookieManager innerManager)
+        {
+            _innerManager = innerManager;
+        }
+
+        public void AppendResponseCookie(IOwinContext context, string key, string value, CookieOptions options)
+        {
+            CheckSameSite(context, options);
+            _innerManager.AppendResponseCookie(context, key, value, options);
+        }
+
+        public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+        {
+            CheckSameSite(context, options);
+            _innerManager.DeleteCookie(context, key, options);
+        }
+
+        public string GetRequestCookie(IOwinContext context, string key)
+        {
+            return _innerManager.GetRequestCookie(context, key);
+        }
+
+        private void CheckSameSite(IOwinContext context, CookieOptions options)
+        {
+            if (IsIOS12(context) && options.SameSite == SameSiteMode.None)
+            {
+                // IOS12 treats SameSite=None as SameSite=Strict. Exclude the option instead.
+                // https://bugs.webkit.org/show_bug.cgi?id=198181
+                options.SameSite = null;
+            }
+        }
+
+        // https://myip.ms/view/comp_browsers/8568/Safari_12.html
+        public static bool IsIOS12(IOwinContext context)
+        {
+            // TODO: Use your User Agent library of choice here.
+            var userAgent = context.Request.Headers["User-Agent"];
+            return userAgent.Contains("iPad; CPU OS 12")
+                || userAgent.Contains("CPU iPhone OS 12"); // Also covers iPod touch
+        }
+    }
+}

--- a/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
+++ b/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
@@ -40,21 +40,22 @@ namespace Katana.Sandbox.WebServer
 
         private void CheckSameSite(IOwinContext context, CookieOptions options)
         {
-            if (IsIOS12(context) && options.SameSite == SameSiteMode.None)
+            if (DisallowsSameSiteNone(context) && options.SameSite == SameSiteMode.None)
             {
-                // IOS12 treats SameSite=None as SameSite=Strict. Exclude the option instead.
+                // IOS12 and Mac OS X 10.14 treat SameSite=None as SameSite=Strict. Exclude the option instead.
                 // https://bugs.webkit.org/show_bug.cgi?id=198181
                 options.SameSite = null;
             }
         }
 
         // https://myip.ms/view/comp_browsers/8568/Safari_12.html
-        public static bool IsIOS12(IOwinContext context)
+        public static bool DisallowsSameSiteNone(IOwinContext context)
         {
             // TODO: Use your User Agent library of choice here.
             var userAgent = context.Request.Headers["User-Agent"];
-            return userAgent.Contains("iPad; CPU OS 12")
-                || userAgent.Contains("CPU iPhone OS 12"); // Also covers iPod touch
+            return userAgent.Contains("CPU iPhone OS 12") // Also covers iPod touch
+                || userAgent.Contains("iPad; CPU OS 12")
+                || (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") && userAgent.Contains("Version/12")); // Mojave & Safari 12
         }
     }
 }

--- a/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
+++ b/tests/Katana.Sandbox.WebServer/SameSiteCookieManager.cs
@@ -55,7 +55,8 @@ namespace Katana.Sandbox.WebServer
             var userAgent = context.Request.Headers["User-Agent"];
             return userAgent.Contains("CPU iPhone OS 12") // Also covers iPod touch
                 || userAgent.Contains("iPad; CPU OS 12")
-                || (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") && userAgent.Contains("Version/12")); // Mojave & Safari 12
+                // Safari 12 and 13 are both broken on Mojave
+                || userAgent.Contains("Macintosh; Intel Mac OS X 10_14");
         }
     }
 }

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -32,6 +33,9 @@ namespace Katana.Sandbox.WebServer
 
         public void Configuration(IAppBuilder app)
         {
+            // For twitter:
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             var logger = app.CreateLogger("Katana.Sandbox.WebServer");
 
             logger.WriteInformation("Application Started");
@@ -125,6 +129,7 @@ namespace Katana.Sandbox.WebServer
             {
                 Wtrealm = "https://tratcheroutlook.onmicrosoft.com/AspNetCoreSample",
                 MetadataAddress = "https://login.windows.net/cdc690f9-b6b8-4023-813a-bae7143d1f87/FederationMetadata/2007-06/FederationMetadata.xml",
+                Wreply = "https://localhost:44318/",
             });
 
             app.UseOpenIdConnectAuthentication(new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions()
@@ -133,7 +138,7 @@ namespace Katana.Sandbox.WebServer
                 ClientId = Environment.GetEnvironmentVariable("oidc:clientid"),
                 ClientSecret = Environment.GetEnvironmentVariable("oidc:clientsecret"),
                 RedirectUri = "https://localhost:44318/",
-                CookieManager = new SystemWebCookieManager(),
+                // CookieManager = new SystemWebCookieManager(),
                 //ResponseType = "code",
                 //ResponseMode = "query",
                 //SaveTokens = true,

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -63,7 +63,8 @@ namespace Katana.Sandbox.WebServer
                 AuthenticationMode = AuthenticationMode.Active,
                 CookieName = CookieAuthenticationDefaults.CookiePrefix + "External",
                 ExpireTimeSpan = TimeSpan.FromMinutes(5),
-                CookieManager = new SystemWebChunkingCookieManager()
+                // CookieManager = new SystemWebChunkingCookieManager()
+                CookieManager = new SameSiteCookieManager()
             });
 
             // https://developers.facebook.com/apps/
@@ -73,7 +74,7 @@ namespace Katana.Sandbox.WebServer
                 AppSecret = Environment.GetEnvironmentVariable("facebook:appsecret"),
                 Scope = { "email" },
                 Fields = { "name", "email" },
-                CookieManager = new SystemWebCookieManager()
+                // CookieManager = new SystemWebCookieManager()
             });
 
             // https://console.developers.google.com/apis/credentials
@@ -134,11 +135,17 @@ namespace Katana.Sandbox.WebServer
 
             app.UseOpenIdConnectAuthentication(new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions()
             {
+                // https://github.com/IdentityServer/IdentityServer4.Demo/blob/master/src/IdentityServer4Demo/Config.cs
+                ClientId = "server.hybrid",
+                ClientSecret = "secret", // for code flow
+                Authority = "https://demo.identityserver.io/",
+                /*
                 Authority = Environment.GetEnvironmentVariable("oidc:authority"),
                 ClientId = Environment.GetEnvironmentVariable("oidc:clientid"),
-                ClientSecret = Environment.GetEnvironmentVariable("oidc:clientsecret"),
                 RedirectUri = "https://localhost:44318/",
+                ClientSecret = Environment.GetEnvironmentVariable("oidc:clientsecret"),*/
                 // CookieManager = new SystemWebCookieManager(),
+                CookieManager = new SameSiteCookieManager(),
                 //ResponseType = "code",
                 //ResponseMode = "query",
                 //SaveTokens = true,


### PR DESCRIPTION
@blowdart we took a community PR https://github.com/aspnet/AspNetKatana/pull/299 that provided the initial SameSite implementation. This PR expands on that to more components, sets None for OIDC, lights up the System.Web implementation, etc..

The updated SystemWebCookieManager won't fix OIDC until System.Web gets patched.

I know there is some duplication here, this is old, decoupled code that we want to limit changes to.

Note that since this API never existed before we were able to make it nullable rather than adding Unspecified (-1) to the enum.

Also fixes https://github.com/aspnet/AspNetKatana/issues/234