### PR TITLE
Fix KeyNotFoundException in OIDCHandler.AuthenticateCoreAsync

### DIFF
--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -384,7 +384,8 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                         ClientSecret = Options.ClientSecret,
                         Code = authorizationResponse.Code,
                         GrantType = OpenIdConnectGrantTypes.AuthorizationCode,
-                        RedirectUri = properties.Dictionary[OpenIdConnectAuthenticationDefaults.RedirectUriUsedForCodeKey]
+                        RedirectUri = properties.Dictionary.ContainsKey(OpenIdConnectAuthenticationDefaults.RedirectUriUsedForCodeKey) ?
+                            properties.Dictionary[OpenIdConnectAuthenticationDefaults.RedirectUriUsedForCodeKey] : string.Empty,
                     };
 
                     var authorizationCodeReceivedNotification = new AuthorizationCodeReceivedNotification(Context, Options)
@@ -393,8 +394,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                         Code = authorizationResponse.Code,
                         JwtSecurityToken = jwt,
                         ProtocolMessage = authorizationResponse,
-                        RedirectUri = properties.Dictionary.ContainsKey(OpenIdConnectAuthenticationDefaults.RedirectUriUsedForCodeKey) ?
-                            properties.Dictionary[OpenIdConnectAuthenticationDefaults.RedirectUriUsedForCodeKey] : string.Empty,
+                        RedirectUri = tokenEndpointRequest.RedirectUri,
                         TokenEndpointRequest = tokenEndpointRequest
                     };
                     await Options.Notifications.AuthorizationCodeReceived(authorizationCodeReceivedNotification);


### PR DESCRIPTION
#315 This was a regression in 4.1 when adding the code flow support. It needed to check if the optional value was in the dictionary before trying to retrieve it. It was doing that a few lines down so I moved it up.