### PR TITLE
HttpListener exception handling

### DIFF
--- a/Katana.sln
+++ b/Katana.sln
@@ -138,6 +138,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "Function
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunctionalTests", "tests\FunctionalTests\FunctionalTests.csproj", "{4EF3F748-16D0-4112-AE43-AACADB3EF8E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Katana.Sandbox.Selfhost", "tests\Katana.Sandbox.Selfhost\Katana.Sandbox.Selfhost.csproj", "{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -308,6 +310,10 @@ Global
 		{4EF3F748-16D0-4112-AE43-AACADB3EF8E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4EF3F748-16D0-4112-AE43-AACADB3EF8E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4EF3F748-16D0-4112-AE43-AACADB3EF8E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -357,5 +363,6 @@ Global
 		{23D90C94-647A-416C-9227-9A0779401EBC} = {10A4935F-4C17-44ED-BB00-D044FC7C77B8}
 		{AA80B4A3-C885-4A7E-AF1A-FC3E89611988} = {10A4935F-4C17-44ED-BB00-D044FC7C77B8}
 		{4EF3F748-16D0-4112-AE43-AACADB3EF8E9} = {DD2E82F1-F3EA-4D1F-B623-9C34440D79D6}
+		{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5} = {D067FB54-B69D-4502-8E2F-676271AC4B86}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Owin.Host.HttpListener/OwinHttpListener.cs
+++ b/src/Microsoft.Owin.Host.HttpListener/OwinHttpListener.cs
@@ -214,30 +214,12 @@ namespace Microsoft.Owin.Host.HttpListener
                 {
                     context = await _listener.GetContextAsync();
                 }
-                catch (ApplicationException ae)
-                {
-                    // These come from the thread pool if HttpListener tries to call BindHandle after the listener has been disposed.
-                    Interlocked.Decrement(ref _currentOutstandingAccepts);
-                    LogHelper.LogException(_logger, "Accept", ae);
-                    return;
-                }
-                catch (HttpListenerException hle)
-                {
-                    // These happen if HttpListener has been disposed
-                    Interlocked.Decrement(ref _currentOutstandingAccepts);
-                    LogHelper.LogException(_logger, "Accept", hle);
-                    return;
-                }
-                catch (ObjectDisposedException ode)
-                {
-                    // These happen if HttpListener has been disposed
-                    Interlocked.Decrement(ref _currentOutstandingAccepts);
-                    LogHelper.LogException(_logger, "Accept", ode);
-                    return;
-                }
                 catch (Exception ex)
                 {
-                    // Some other unknown error. Log it and try to keep going.
+                    // HttpListenerException happen if HttpListener has been disposed, or if the client disconnects mid request.
+                    // ObjectDisposedException happen if HttpListener has been disposed.
+                    // ApplicationException come from the thread pool if HttpListener tries to call BindHandle after the listener has been disposed.
+                    // Log it and try to keep going. Let IsListening break the loop.
                     Interlocked.Decrement(ref _currentOutstandingAccepts);
                     LogHelper.LogException(_logger, "Accept", ex);
                     continue;

--- a/tests/Katana.Sandbox.Selfhost/App.config
+++ b/tests/Katana.Sandbox.Selfhost/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/tests/Katana.Sandbox.Selfhost/Katana.Sandbox.Selfhost.csproj
+++ b/tests/Katana.Sandbox.Selfhost/Katana.Sandbox.Selfhost.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9F2F31EF-6017-48CC-88D6-EC4FF4FEAAA5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Katana.Sandbox.Selfhost</RootNamespace>
+    <AssemblyName>Katana.Sandbox.Selfhost</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.Diagnostics\Microsoft.Owin.Diagnostics.csproj">
+      <Project>{670915f7-f111-42ff-b004-39379a9d5951}</Project>
+      <Name>Microsoft.Owin.Diagnostics</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.FileSystems\Microsoft.Owin.FileSystems.csproj">
+      <Project>{63988a9b-fa70-4bba-8c7e-784145384f7c}</Project>
+      <Name>Microsoft.Owin.FileSystems</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.Host.HttpListener\Microsoft.Owin.Host.HttpListener.csproj">
+      <Project>{9f0c72d8-e43f-4f01-9deb-919191911919}</Project>
+      <Name>Microsoft.Owin.Host.HttpListener</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.Hosting\Microsoft.Owin.Hosting.csproj">
+      <Project>{c225eb2f-e7a7-463f-b058-1705f204978e}</Project>
+      <Name>Microsoft.Owin.Hosting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin.StaticFiles\Microsoft.Owin.StaticFiles.csproj">
+      <Project>{f31a42db-2f57-4dac-b2bc-106f2d6f3c82}</Project>
+      <Name>Microsoft.Owin.StaticFiles</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.Owin\Microsoft.Owin.csproj">
+      <Project>{0db69cae-b0bc-4688-9467-66b4c1023d3f}</Project>
+      <Name>Microsoft.Owin</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Katana.Sandbox.Selfhost/Program.cs
+++ b/tests/Katana.Sandbox.Selfhost/Program.cs
@@ -1,0 +1,30 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Microsoft.Owin.Hosting;
+using Microsoft.Owin.Host.HttpListener;
+using Owin;
+
+namespace Katana.Sandbox.Selfhost
+{
+    class Program
+    {
+        static void Main()
+        {
+            var address = "http://localhost:8000/";
+            using (var server = WebApp.Start(address, appBuilder =>
+            {
+                var owinHttpListener = appBuilder.Properties[typeof(OwinHttpListener).FullName] as OwinHttpListener;
+                appBuilder.Use(async (context, next) => await context.Response.WriteAsync("Hello world!"));
+            }))
+            {
+                Console.WriteLine("Listening on " + address);
+                Console.ReadKey();
+            }
+        }
+    }
+}

--- a/tests/Katana.Sandbox.Selfhost/Properties/AssemblyInfo.cs
+++ b/tests/Katana.Sandbox.Selfhost/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Katana.Sandbox.Selfhost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Katana.Sandbox.Selfhost")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9f2f31ef-6017-48cc-88d6-ec4ff4feaaa5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Katana.Sandbox.Selfhost/packages.config
+++ b/tests/Katana.Sandbox.Selfhost/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Owin" version="1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
#314 OwinHttpListener assumed HttpListenerException would only be thrown if the HttpListener had been disposed. However, a partner identified another scenario where it can throw. These specialized catch blocks were redundant anyways, they all did the same thing. I've removed them and let everything fall through to the generic block. This now more close matches the code in [Core](https://github.com/aspnet/AspNetCore/blob/ec8304ae85d5a94cf3cd5efc5f89b986bc4eafd2/src/Servers/HttpSys/src/MessagePump.cs#L169).
@scottlerch