### PR TITLE
Remove cookie name decoding

### DIFF
--- a/src/Microsoft.Owin/RequestCookieCollection.cs
+++ b/src/Microsoft.Owin/RequestCookieCollection.cs
@@ -37,8 +37,11 @@ namespace Microsoft.Owin
             get
             {
                 string value;
-                Store.TryGetValue(key, out value);
-                return value;
+                if (Store.TryGetValue(key, out value) || Store.TryGetValue(Uri.EscapeDataString(key), out value))
+                {
+                    return value;
+                }
+                return null;
             }
         }
 

--- a/tests/Microsoft.Owin.Tests/FormsTests.cs
+++ b/tests/Microsoft.Owin.Tests/FormsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Owin.Tests
         private static readonly string[] RawValues = new[] { "v1", "v2, v3", "\"v4, b\"", "v5, v6", "v7", };
         private const string JoinedValues = "v1,v2, v3,\"v4, b\",v5, v6,v7";
 
-        private const string OriginalFormsString = "q1=v1&q2=v2,b&q3=v3&q3=v4&q4&q5=v5&q5=v5";
+        private const string OriginalFormsString = "q1=v1&q2=v2,b&q3=v3&q3=v4&q4&q5=v5&q5=v+5";
 
         [Fact]
         public void ParseForm()
@@ -30,7 +30,7 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v5,v+5", form.Get("Q5"));
             Assert.True(stream.CanRead);
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v5,v+5", form.Get("Q5"));
         }
 
         [Fact]
@@ -107,14 +107,14 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v5,v+5", form.Get("Q5"));
 
             form = request.ReadFormAsync().Result;
             Assert.Equal("v1", form.Get("q1"));
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v5,v+5", form.Get("Q5"));
         }
     }
 }

--- a/tests/Microsoft.Owin.Tests/Microsoft.Owin.Tests.csproj
+++ b/tests/Microsoft.Owin.Tests/Microsoft.Owin.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Builder\AppBuilderTestExtensions.cs" />
     <Compile Include="Builder\AppBuilderTests.cs" />
     <Compile Include="CookieChunkingTests.cs" />
+    <Compile Include="RequestCookieTests.cs" />
     <Compile Include="FormsTests.cs" />
     <Compile Include="HeaderTests.cs" />
     <Compile Include="HostStringTests.cs" />

--- a/tests/Microsoft.Owin.Tests/RequestCookieTests.cs
+++ b/tests/Microsoft.Owin.Tests/RequestCookieTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Microsoft.Owin.Tests
+{
+    public class RequestCookieTests
+    {
+        [Theory]
+        [InlineData("key=value", "key", "value")]
+        [InlineData("__secure-key=value", "__secure-key", "value")]
+        [InlineData("key%2C=%21value", "key,", "!value")]
+        [InlineData("ke%23y%2C=val%5Eue", "ke#y,", "val^ue")]
+        [InlineData("base64=QUI%2BREU%2FRw%3D%3D", "base64", "QUI+REU/Rw==")]
+        [InlineData("base64=QUI+REU/Rw==", "base64", "QUI+REU/Rw==")]
+        public void UnEscapesValues(string input, string expectedKey, string expectedValue)
+        {
+            var context = new OwinRequest();
+            context.Headers["Cookie"] = input;
+            var cookies = context.Cookies;
+
+            Assert.Equal(1, cookies.Count());
+            Assert.Equal(Uri.EscapeDataString(expectedKey), cookies.Single().Key);
+            Assert.Equal(expectedValue, cookies[expectedKey]);
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/23578 https://github.com/dotnet/aspnetcore/pull/24264

Decoding arbitrary input allows spoofing of special inputs like __Host- with encoded values like __%48ost-.

Fix: Only compare to known values. e.g. the key the developer passes in with the encoding we would have used.

This fix works seamlessly for the indexer but leaves the encoded value in enumerator.

Note Katana does not have quirks or AppContext switches. That should be OK because Katana is not bundled as part of a framework, it's an opt-in package upgrade.

This PR had to do a little more more work than the AspNetCore 2.1 version because Katana shared the same parser for cookies, forms, and query strings. The three are close, but there are a few differences people have complained about (https://github.com/aspnet/HttpAbstractions/issues/547). AspNetCore changed to using a separate parser for each data type a long time ago.

TODO: versioning. This will probably be versioned as 4.1.1.