### PR TITLE
Update OAuth endpoints, fix form un-escaping

### DIFF
--- a/src/Microsoft.Owin.Security.Facebook/Constants.cs
+++ b/src/Microsoft.Owin.Security.Facebook/Constants.cs
@@ -7,8 +7,9 @@ namespace Microsoft.Owin.Security.Facebook
     {
         public const string DefaultAuthenticationType = "Facebook";
 
-        internal const string AuthorizationEndpoint = "https://www.facebook.com/v2.8/dialog/oauth";
-        internal const string TokenEndpoint = "https://graph.facebook.com/v2.8/oauth/access_token";
-        internal const string UserInformationEndpoint = "https://graph.facebook.com/v2.8/me";
+        // https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login
+        internal const string AuthorizationEndpoint = "https://www.facebook.com/v8.0/dialog/oauth";
+        internal const string TokenEndpoint = "https://graph.facebook.com/v8.0/oauth/access_token";
+        internal const string UserInformationEndpoint = "https://graph.facebook.com/v8.0/me";
     }
 }

--- a/src/Microsoft.Owin.Security.Google/Constants.cs
+++ b/src/Microsoft.Owin.Security.Google/Constants.cs
@@ -7,8 +7,9 @@ namespace Microsoft.Owin.Security.Google
     {
         internal const string DefaultAuthenticationType = "Google";
 
+        // https://developers.google.com/identity/protocols/oauth2/web-server#httprest
         internal const string AuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
-        internal const string TokenEndpoint = "https://www.googleapis.com/oauth2/v4/token";
+        internal const string TokenEndpoint = "https://oauth2.googleapis.com/token";
         internal const string UserInformationEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo";
     }
 }

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/Constants.cs
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/Constants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
     {
         internal const string DefaultAuthenticationType = "Microsoft";
 
+        // https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user
         internal const string AuthorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
         internal const string TokenEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
         internal const string UserInformationEndpoint = "https://graph.microsoft.com/v1.0/me";

--- a/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationHandler.cs
@@ -21,8 +21,11 @@ namespace Microsoft.Owin.Security.Twitter
     {
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         private const string StateCookie = "__TwitterState";
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/request_token
         private const string RequestTokenEndpoint = "https://api.twitter.com/oauth/request_token";
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/authenticate
         private const string AuthenticationEndpoint = "https://api.twitter.com/oauth/authenticate?oauth_token=";
+        // https://developer.twitter.com/en/docs/basics/authentication/api-reference/access_token
         private const string AccessTokenEndpoint = "https://api.twitter.com/oauth/access_token";
 
         private readonly HttpClient _httpClient;

--- a/src/Microsoft.Owin/Infrastructure/OwinHelpers.cs
+++ b/src/Microsoft.Owin/Infrastructure/OwinHelpers.cs
@@ -820,7 +820,7 @@ namespace Microsoft.Owin.Infrastructure
         {
             IDictionary<string, string[]> form = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
             var accumulator = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-            ParseDelimited(text, new[] { '&' }, AppendItemCallback, decodePlus: false, decodeKey: true, state: accumulator);
+            ParseDelimited(text, new[] { '&' }, AppendItemCallback, decodePlus: true, decodeKey: true, state: accumulator);
             foreach (var kv in accumulator)
             {
                 form.Add(kv.Key, kv.Value.ToArray());

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -136,13 +136,13 @@ namespace Katana.Sandbox.WebServer
             app.UseOpenIdConnectAuthentication(new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions()
             {
                 // https://github.com/IdentityServer/IdentityServer4.Demo/blob/master/src/IdentityServer4Demo/Config.cs
-                ClientId = "server.hybrid",
+                ClientId = "hybrid",
                 ClientSecret = "secret", // for code flow
                 Authority = "https://demo.identityserver.io/",
+                RedirectUri = "https://localhost:44318/signin-oidc",
                 /*
                 Authority = Environment.GetEnvironmentVariable("oidc:authority"),
                 ClientId = Environment.GetEnvironmentVariable("oidc:clientid"),
-                RedirectUri = "https://localhost:44318/",
                 ClientSecret = Environment.GetEnvironmentVariable("oidc:clientsecret"),*/
                 // CookieManager = new SystemWebCookieManager(),
                 CookieManager = new SameSiteCookieManager(),

--- a/tests/Microsoft.Owin.Tests/FormsTests.cs
+++ b/tests/Microsoft.Owin.Tests/FormsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Owin.Tests
         private static readonly string[] RawValues = new[] { "v1", "v2, v3", "\"v4, b\"", "v5, v6", "v7", };
         private const string JoinedValues = "v1,v2, v3,\"v4, b\",v5, v6,v7";
 
-        private const string OriginalFormsString = "q1=v1&q2=v2,b&q3=v3&q3=v4&q4&q5=v5&q5=v+5";
+        private const string OriginalFormsString = "q1=v1&q2=v2,b&q3=v3&q3=v4&q4&q5=v5&q5=v5&q+6=v+6";
 
         [Fact]
         public void ParseForm()
@@ -30,7 +30,8 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v+5", form.Get("Q5"));
+            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v 6", form.Get("Q 6"));
             Assert.True(stream.CanRead);
         }
 
@@ -89,7 +90,8 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v+5", form.Get("Q5"));
+            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v 6", form.Get("Q 6"));
         }
 
         [Fact]
@@ -107,14 +109,16 @@ namespace Microsoft.Owin.Tests
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v+5", form.Get("Q5"));
+            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v 6", form.Get("Q 6"));
 
             form = request.ReadFormAsync().Result;
             Assert.Equal("v1", form.Get("q1"));
             Assert.Equal("v2,b", form.Get("Q2"));
             Assert.Equal("v3,v4", form.Get("q3"));
             Assert.Null(form.Get("q4"));
-            Assert.Equal("v5,v+5", form.Get("Q5"));
+            Assert.Equal("v5,v5", form.Get("Q5"));
+            Assert.Equal("v 6", form.Get("Q 6"));
         }
     }
 }


### PR DESCRIPTION
#327 - our regular update of oauth endpoints. No observable behavior changes.

When manually testing I realized that #368 broke form decoding in two paces when replacing `+` with ` `.
The first was fixed by https://github.com/aspnet/AspNetKatana/pull/379

I've included the fix for the second one in this PR because WsFed doesn't work without it. In short, plus decoding needs to be turned on for forms parsing, we only needed to turn it off for cookies.