### PR TITLE
Backport ASP.NET Core PKCE Support to OpenIdConnectAuthenticationHandler

### DIFF
--- a/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.csproj
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/Microsoft.Owin.Security.OpenIdConnect.csproj
@@ -86,6 +86,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Notifications\AuthorizationCodeReceivedNotification.cs" />
     <Compile Include="Notifications\TokenResponseReceivedNotification.cs" />
+    <Compile Include="OAuthConstants.cs" />
     <Compile Include="OpenIdConnectAuthenticationDefaults.cs" />
     <Compile Include="OpenIdConnectAuthenticationExtensions.cs" />
     <Compile Include="OpenidConnectAuthenticationHandler.cs" />

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OAuthConstants.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OAuthConstants.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Owin.Security.OpenIdConnect
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Auth",
+        Justification = "OAuth2 is a valid word.")]
+    internal static class OAuthConstants
+    {
+        /// <summary>
+        /// code_verifier defined in https://tools.ietf.org/html/rfc7636
+        /// </summary>
+        public const string CodeVerifierKey = "code_verifier";
+
+        /// <summary>
+        /// code_challenge defined in https://tools.ietf.org/html/rfc7636
+        /// </summary>
+        public const string CodeChallengeKey = "code_challenge";
+
+        /// <summary>
+        /// code_challenge_method defined in https://tools.ietf.org/html/rfc7636
+        /// </summary>
+        public const string CodeChallengeMethodKey = "code_challenge_method";
+
+        /// <summary>
+        /// S256 defined in https://tools.ietf.org/html/rfc7636
+        /// </summary>
+        public const string CodeChallengeMethodS256 = "S256";
+    }
+}

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
         /// <para>TokenValidationParameters: new <see cref="TokenValidationParameters"/> with AuthenticationType = authenticationType.</para>
         /// <para>UseTokenLifetime: true.</para>
         /// <para>RedeemCode: false.</para>
+        /// <para>UsePkce: false.</para>
         /// </remarks>
         /// <param name="authenticationType"> will be used to when creating the <see cref="System.Security.Claims.ClaimsIdentity"/> for the AuthenticationType property.</param>
         [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions.set_Caption(System.String)", Justification = "Not a LOC field")]
@@ -71,6 +72,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
             UseTokenLifetime = true;
             CookieManager = new CookieManager();
             RedeemCode = false;
+            UsePkce = false;
         }
 
         /// <summary>
@@ -322,5 +324,15 @@ namespace Microsoft.Owin.Security.OpenIdConnect
         /// This property is set to <c>false</c> by default.
         /// </summary>
         public bool RedeemCode { get; set; }
+
+        /// <summary>
+        /// Enables or disables the use of the Proof Key for Code Exchange (PKCE) standard.
+        /// This only applies when the <see cref="ResponseType"/> is set to <see cref="OpenIdConnectResponseType.Code"/>.
+        /// See https://tools.ietf.org/html/rfc7636.
+        /// The default value is `true`.
+        /// </summary>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Pkce",
+        Justification = "Pkce is a valid acronym.")]
+        public bool UsePkce { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
         /// <para>TokenValidationParameters: new <see cref="TokenValidationParameters"/> with AuthenticationType = authenticationType.</para>
         /// <para>UseTokenLifetime: true.</para>
         /// <para>RedeemCode: false.</para>
-        /// <para>UsePkce: false.</para>
+        /// <para>UsePkce: true.</para>
         /// </remarks>
         /// <param name="authenticationType"> will be used to when creating the <see cref="System.Security.Claims.ClaimsIdentity"/> for the AuthenticationType property.</param>
         [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions.set_Caption(System.String)", Justification = "Not a LOC field")]

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationOptions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
             UseTokenLifetime = true;
             CookieManager = new CookieManager();
             RedeemCode = false;
-            UsePkce = false;
+            UsePkce = true;
         }
 
         /// <summary>

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -166,17 +166,12 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                     using (HashAlgorithm hash = SHA256.Create())
                     {
                         byte[] bytes = new byte[32];
-
                         randomNumberGenerator.GetBytes(bytes);
-
                         string codeVerifier = TextEncodings.Base64Url.Encode(bytes);
 
-                        // Store this for use during the code redemption. See RunAuthorizationCodeReceivedEventAsync.
+                        // Store this for use during the code redemption.
                         properties.Dictionary.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
-
-                        
                         byte[] challengeBytes = hash.ComputeHash(Encoding.UTF8.GetBytes(codeVerifier));
-
                         string codeChallenge = TextEncodings.Base64Url.Encode(challengeBytes);
 
                         openIdConnectMessage.Parameters.Add(OAuthConstants.CodeChallengeKey, codeChallenge);

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Logging;
+using Microsoft.Owin.Security.DataHandler.Encoder;
 using Microsoft.Owin.Security.Infrastructure;
 using Microsoft.Owin.Security.Notifications;
 
@@ -155,9 +156,35 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                     RequestType = OpenIdConnectRequestType.Authentication,
                     Resource = Options.Resource,
                     ResponseType = Options.ResponseType,
-                    Scope = Options.Scope,
-                    State = OpenIdConnectAuthenticationDefaults.AuthenticationPropertiesKey + "=" + Uri.EscapeDataString(Options.StateDataFormat.Protect(properties)),
+                    Scope = Options.Scope
                 };
+
+                // https://tools.ietf.org/html/rfc7636
+                if (Options.UsePkce && Options.ResponseType == OpenIdConnectResponseType.Code)
+                {
+                    using (RandomNumberGenerator randomNumberGenerator = RandomNumberGenerator.Create())
+                    using (HashAlgorithm hash = SHA256.Create())
+                    {
+                        byte[] bytes = new byte[32];
+
+                        randomNumberGenerator.GetBytes(bytes);
+
+                        string codeVerifier = TextEncodings.Base64Url.Encode(bytes);
+
+                        // Store this for use during the code redemption. See RunAuthorizationCodeReceivedEventAsync.
+                        properties.Dictionary.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
+
+                        
+                        byte[] challengeBytes = hash.ComputeHash(Encoding.UTF8.GetBytes(codeVerifier));
+
+                        string codeChallenge = TextEncodings.Base64Url.Encode(challengeBytes);
+
+                        openIdConnectMessage.Parameters.Add(OAuthConstants.CodeChallengeKey, codeChallenge);
+                        openIdConnectMessage.Parameters.Add(OAuthConstants.CodeChallengeMethodKey, OAuthConstants.CodeChallengeMethodS256);
+                    }
+                }
+
+                openIdConnectMessage.State = OpenIdConnectAuthenticationDefaults.AuthenticationPropertiesKey + "=" + Uri.EscapeDataString(Options.StateDataFormat.Protect(properties));
 
                 // Omitting the response_mode parameter when it already corresponds to the default
                 // response_mode used for the specified response_type is recommended by the specifications.
@@ -397,6 +424,15 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                         RedirectUri = tokenEndpointRequest.RedirectUri,
                         TokenEndpointRequest = tokenEndpointRequest
                     };
+
+                    // PKCE https://tools.ietf.org/html/rfc7636#section-4.5
+                    string codeVerifier;
+                    if (properties.Dictionary.TryGetValue(OAuthConstants.CodeVerifierKey, out codeVerifier))
+                    {
+                        tokenEndpointRequest.Parameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier);
+                        properties.Dictionary.Remove(OAuthConstants.CodeVerifierKey);
+                    }
+
                     await Options.Notifications.AuthorizationCodeReceived(authorizationCodeReceivedNotification);
                     if (authorizationCodeReceivedNotification.HandledResponse)
                     {

--- a/tests/Katana.Sandbox.WebServer/Startup.cs
+++ b/tests/Katana.Sandbox.WebServer/Startup.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using Katana.Sandbox.WebServer;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin;
 using Microsoft.Owin.Extensions;
 using Microsoft.Owin.Host.SystemWeb;
@@ -135,9 +136,9 @@ namespace Katana.Sandbox.WebServer
 
             app.UseOpenIdConnectAuthentication(new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationOptions()
             {
-                // https://github.com/IdentityServer/IdentityServer4.Demo/blob/master/src/IdentityServer4Demo/Config.cs
-                ClientId = "hybrid",
-                ClientSecret = "secret", // for code flow
+                // https://github.com/IdentityServer/IdentityServer4.Demo/blob/main/src/IdentityServer4Demo/Config.cs
+                ClientId = "interactive.confidential.short", // client requires pkce
+                ClientSecret = "secret",
                 Authority = "https://demo.identityserver.io/",
                 RedirectUri = "https://localhost:44318/signin-oidc",
                 /*
@@ -146,11 +147,11 @@ namespace Katana.Sandbox.WebServer
                 ClientSecret = Environment.GetEnvironmentVariable("oidc:clientsecret"),*/
                 // CookieManager = new SystemWebCookieManager(),
                 CookieManager = new SameSiteCookieManager(),
-                //ResponseType = "code",
-                //ResponseMode = "query",
-                //SaveTokens = true,
-                //Scope = "openid profile offline_access",
-                //RedeemCode = true,
+                ResponseType = OpenIdConnectResponseType.Code,
+                ResponseMode = OpenIdConnectResponseMode.Query,
+                SaveTokens = true,
+                Scope = "openid profile offline_access",
+                RedeemCode = true,
                 //Notifications = new Microsoft.Owin.Security.OpenIdConnect.OpenIdConnectAuthenticationNotifications
                 //{
                 //    AuthorizationCodeReceived = async n =>
@@ -166,6 +167,7 @@ namespace Katana.Sandbox.WebServer
                 //        n.HandleCodeRedemption(message);
                 //    }
                 //}
+                UsePkce = true,
             });
 
             /*

--- a/tests/Microsoft.Owin.Security.Tests/Microsoft.Owin.Security.Tests.csproj
+++ b/tests/Microsoft.Owin.Security.Tests/Microsoft.Owin.Security.Tests.csproj
@@ -43,6 +43,12 @@
       <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net45\Microsoft.IdentityModel.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net45\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net45\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.3.0\lib\net45\Microsoft.IdentityModel.Tokens.dll</HintPath>
       <Private>True</Private>
@@ -89,6 +95,7 @@
     <Compile Include="Facebook\FacebookMiddlewareTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Google\GoogleOAuth2MiddlewareTests.cs" />
+    <Compile Include="OpenIdConnect\OpenIdConnectMiddlewareTests.cs" />
     <Compile Include="MicrosoftAccount\MicrosoftAccountMiddlewareTests.cs" />
     <Compile Include="OAuth\OAuth2AuthorizationCustomGrantTests.cs" />
     <Compile Include="OAuth\OAuth2BearerTokenTests.cs" />

--- a/tests/Microsoft.Owin.Security.Tests/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/OpenIdConnect/OpenIdConnectMiddlewareTests.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.OpenIdConnect;
+using Microsoft.Owin.Testing;
+using Owin;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Microsoft.Owin.Security.Tests.OpenIdConnect
+{
+    public class OpenIdConnectMiddlewareTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ChallengeIncludesPkceIfRequested(bool include)
+        {
+            var options = new OpenIdConnectAuthenticationOptions()
+                          {
+                              Authority = "https://demo.identityserver.io",
+                              ClientId = "Test Client Id",
+                              ClientSecret = "Test Client Secret",
+                              UsePkce = include,
+                              ResponseType = OpenIdConnectResponseType.Code
+            };
+            var server = CreateServer(
+                app => app.UseOpenIdConnectAuthentication(options),
+                context =>
+                {
+                    context.Authentication.Challenge("OpenIdConnect");
+                    return true;
+                });
+
+            var transaction = await SendAsync(server, "http://example.com/challenge");
+
+            var res = transaction.Response;
+            Assert.Equal(HttpStatusCode.Redirect, res.StatusCode);
+            Assert.NotNull(res.Headers.Location);
+
+            if (include)
+            {
+                Assert.Contains("code_challenge=", res.Headers.Location.Query);
+                Assert.Contains("code_challenge_method=S256", res.Headers.Location.Query);
+            }
+            else
+            {
+                Assert.DoesNotContain("code_challenge=", res.Headers.Location.Query);
+                Assert.DoesNotContain("code_challenge_method=", res.Headers.Location.Query);
+            }
+        }
+
+        [Theory]
+        [InlineData(OpenIdConnectResponseType.Token)]
+        [InlineData(OpenIdConnectResponseType.IdToken)]
+        [InlineData(OpenIdConnectResponseType.CodeIdToken)]
+        public async Task ChallengeDoesNotIncludePkceForOtherResponseTypes(string responseType)
+        {
+            var options = new OpenIdConnectAuthenticationOptions()
+                          {
+                              Authority = "https://demo.identityserver.io",
+                              ClientId = "Test Client Id",
+                              ClientSecret = "Test Client Secret",
+                              UsePkce = true,
+                              ResponseType = responseType
+                          };
+            var server = CreateServer(
+                app => app.UseOpenIdConnectAuthentication(options),
+                context =>
+                {
+                    context.Authentication.Challenge("OpenIdConnect");
+                    return true;
+                });
+
+            var transaction = await SendAsync(server, "http://example.com/challenge");
+
+            var res = transaction.Response;
+            Assert.Equal(HttpStatusCode.Redirect, res.StatusCode);
+            Assert.NotNull(res.Headers.Location);
+
+            Assert.DoesNotContain("code_challenge=", res.Headers.Location.Query);
+            Assert.DoesNotContain("code_challenge_method=", res.Headers.Location.Query);
+        }
+
+
+        private static TestServer CreateServer(Action<IAppBuilder> configure, Func<IOwinContext, bool> handler)
+        {
+            return TestServer.Create(app =>
+            {
+                app.Properties["host.AppName"] = "OpenIdConnect.Owin.Security.Tests";
+                app.UseCookieAuthentication(new CookieAuthenticationOptions
+                {
+                    AuthenticationType = "External"
+                });
+                app.SetDefaultSignInAsAuthenticationType("External");
+                if (configure != null)
+                {
+                    configure(app);
+                }
+                app.Use(async (context, next) =>
+                {
+                    if (handler == null || !handler(context))
+                    {
+                        await next();
+                    }
+                });
+            });
+        }
+
+        private static async Task<Transaction> SendAsync(TestServer server, string uri, string cookieHeader = null)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            if (!string.IsNullOrEmpty(cookieHeader))
+            {
+                request.Headers.Add("Cookie", cookieHeader);
+            }
+            var transaction = new Transaction
+            {
+                Request = request,
+                Response = await server.HttpClient.SendAsync(request),
+            };
+            if (transaction.Response.Headers.Contains("Set-Cookie"))
+            {
+                transaction.SetCookie = transaction.Response.Headers.GetValues("Set-Cookie").ToList();
+            }
+            transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
+
+            if (transaction.Response.Content != null &&
+                transaction.Response.Content.Headers.ContentType != null &&
+                transaction.Response.Content.Headers.ContentType.MediaType == "text/xml")
+            {
+                transaction.ResponseElement = XElement.Parse(transaction.ResponseText);
+            }
+            return transaction;
+        }
+
+        private class Transaction
+        {
+            public HttpRequestMessage Request { get; set; }
+            public HttpResponseMessage Response { get; set; }
+            public IList<string> SetCookie { get; set; }
+            public string ResponseText { get; set; }
+            public XElement ResponseElement { get; set; }
+
+            public string AuthenticationCookieValue
+            {
+                get
+                {
+                    if (SetCookie != null && SetCookie.Count > 0)
+                    {
+                        var authCookie = SetCookie.SingleOrDefault(c => c.Contains(".AspNet.External="));
+                        if (authCookie != null)
+                        {
+                            return authCookie.Substring(0, authCookie.IndexOf(';'));
+                        }
+                    }
+
+                    return null;
+                }
+            }
+
+            public string FindClaimValue(string claimType)
+            {
+                XElement claim = ResponseElement.Elements("claim").SingleOrDefault(elt => elt.Attribute("type").Value == claimType);
+                if (claim == null)
+                {
+                    return null;
+                }
+                return claim.Attribute("value").Value;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Owin.Security.Tests/packages.config
+++ b/tests/Microsoft.Owin.Security.Tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
This adds PKCE Support to the OpenIdConnectAuthenticationHandler from #334 

The implementation is a port from ASP.NET Core respecting some of the missing APIs:
https://github.com/dotnet/aspnetcore/blob/8a81194f372fa6fe63ded2d932d379955854d080/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs#L386
and
https://github.com/dotnet/aspnetcore/blob/8a81194f372fa6fe63ded2d932d379955854d080/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs#L1134

I've added some unit test to cover the challenge redirects and tested the implementation using the sandbox and IdentityServer4.

It could be possible to upgrade the [IdentityModel.*](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases) packages as well. But I'm not aware if this would cause any braking changes.
