### PR TITLE
Warn that SecurityTokenValidated is not that last step 

### DIFF
--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationNotifications.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationNotifications.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Owin.Security.OpenIdConnect
         public Func<SecurityTokenReceivedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenReceived { get; set; }
 
         /// <summary>
-        /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
+        /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated. Note there are additional checks after this
+        /// event that validate other aspects of the authentication flow like the nonce.
         /// </summary>
         public Func<SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>, Task> SecurityTokenValidated { get; set; }
 


### PR DESCRIPTION
Fixes #405. Users have been confused by SecurityTokenValidated, thinking it indicated that all authentication is finished. In fact it only refers to one step of the validation, the token itself. Adding a clarifying comment.

This should be ported forward to AspNetCore as well.