### PR TITLE
Update Facebook OAuth endpoints, tests

### DIFF
--- a/src/Microsoft.Owin.Security.Facebook/Constants.cs
+++ b/src/Microsoft.Owin.Security.Facebook/Constants.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Owin.Security.Facebook
         public const string DefaultAuthenticationType = "Facebook";
 
         // https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login
-        internal const string AuthorizationEndpoint = "https://www.facebook.com/v8.0/dialog/oauth";
-        internal const string TokenEndpoint = "https://graph.facebook.com/v8.0/oauth/access_token";
-        internal const string UserInformationEndpoint = "https://graph.facebook.com/v8.0/me";
+        internal const string AuthorizationEndpoint = "https://www.facebook.com/v10.0/dialog/oauth";
+        internal const string TokenEndpoint = "https://graph.facebook.com/v10.0/oauth/access_token";
+        internal const string UserInformationEndpoint = "https://graph.facebook.com/v10.0/me";
     }
 }

--- a/tests/Microsoft.Owin.Security.Tests/Facebook/FacebookMiddlewareTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/Facebook/FacebookMiddlewareTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Owin.Security.Tests.Facebook
             var transaction = await SendAsync(server, "http://example.com/challenge");
             transaction.Response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             var location = transaction.Response.Headers.Location.AbsoluteUri;
-            location.ShouldContain("https://www.facebook.com/v2.8/dialog/oauth");
+            location.ShouldContain("https://www.facebook.com/v10.0/dialog/oauth");
             location.ShouldContain("?response_type=code");
             location.ShouldContain("&client_id=");
             location.ShouldContain("&redirect_uri=");

--- a/tests/Microsoft.Owin.Security.Tests/Google/GoogleOAuth2MiddlewareTests.cs
+++ b/tests/Microsoft.Owin.Security.Tests/Google/GoogleOAuth2MiddlewareTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Owin.Security.Tests.Google
                 {
                     Sender = async req =>
                         {
-                            if (req.RequestUri.AbsoluteUri == "https://www.googleapis.com/oauth2/v4/token")
+                            if (req.RequestUri.AbsoluteUri == "https://oauth2.googleapis.com/token")
                             {
                                 return await ReturnJsonResponse(new
                                 {
@@ -351,7 +351,7 @@ namespace Microsoft.Owin.Security.Tests.Google
                 {
                     Sender = async req =>
                     {
-                        if (req.RequestUri.AbsoluteUri == "https://www.googleapis.com/oauth2/v4/token")
+                        if (req.RequestUri.AbsoluteUri == "https://oauth2.googleapis.com/token")
                         {
                             return await ReturnJsonResponse(new
                             {


### PR DESCRIPTION
#327 This is our regular refresh of OAuth endpoints. Only Facebook has changed, but a few of the other tests were out of date.