### PR TITLE
Do not call End/Abort on disconnect 

### DIFF
--- a/src/Microsoft.Owin.Host.HttpListener/RequestProcessing/OwinHttpListenerContext.cs
+++ b/src/Microsoft.Owin.Host.HttpListener/RequestProcessing/OwinHttpListenerContext.cs
@@ -89,7 +89,6 @@ namespace Microsoft.Owin.Host.HttpListener.RequestProcessing
 
         private void CancelDisconnectToken()
         {
-            // TODO: LOG
             // Lazy initialized
             if (_cts != null)
             {


### PR DESCRIPTION
Fixes #430

Http.Sys always fires the connection disconnect callback even if requests complete successfully. There's a race where the disconnect can fire during the write call that finishes the response. For HTTP/2 this callback is per-request, not per connection, making the race more likely to be observable.

Katana's old logic would end up Aborting the response whenever the disconnect fired. This could cause the final WriteAsync call to throw even if it succeeded.

The new logic will cancel the request CTS without calling Abort. Abort is only called if exceptions are thrown from the application. This matches the behavior of HttpSysServer in ASP.NET Core. This does not get rid of the race condition for the disconnect callback, it only mitigates the write error. Passing the the token to the WriteAsync operation could still cause it to fail.

Testing:
- Existing automated tests to check for regressions.
- Manual testing for the race condition.
- We'll have the customer test a nightly build.