### PR TITLE
Only add nonce if we are redirecting (#440)

### DIFF
--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenidConnectAuthenticationHandler.cs
@@ -190,11 +190,6 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                     openIdConnectMessage.ResponseMode = Options.ResponseMode;
                 }
 
-                if (Options.ProtocolValidator.RequireNonce)
-                {
-                    AddNonceToMessage(openIdConnectMessage);
-                }
-
                 var notification = new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(Context, Options)
                 {
                     ProtocolMessage = openIdConnectMessage
@@ -204,6 +199,11 @@ namespace Microsoft.Owin.Security.OpenIdConnect
 
                 if (!notification.HandledResponse)
                 {
+                    if (Options.ProtocolValidator.RequireNonce)
+                    {
+                        AddNonceToMessage(openIdConnectMessage);
+                    }
+
                     string redirectUri = notification.ProtocolMessage.CreateAuthenticationRequestUrl();
                     if (!Uri.IsWellFormedUriString(redirectUri, UriKind.Absolute))
                     {


### PR DESCRIPTION
This is a proposed fix for #440 that only adds the nonce cookie when the RedirectToIdentityProvider is not handled