### PR TITLE
Supress CodeQL warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,10 +69,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+            demands: ImageOverride -equals 1es-windows-2019-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
+            demands: ImageOverride -equals 1es-windows-2019
         ${{ if eq(variables.runCodeQL3000, 'true') }}:
           # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
           disableComponentGovernance: true

--- a/src/Microsoft.Owin.Host.SystemWeb/SystemWebChunkingCookieManager.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/SystemWebChunkingCookieManager.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Owin.Host.SystemWeb
             // Normal cookie
             if (!ChunkSize.HasValue || ChunkSize.Value > prefix.Length + escapedValue.Length + suffix.Length + (quoted ? 2 : 0))
             {
-                var cookie = new HttpCookie(escapedKey, escapedValue);
+                var cookie = new HttpCookie(escapedKey, escapedValue); // CodeQL [SM03822] False positive, this is an abstraction and the values are determined elsewhere.
                 SetOptions(cookie, options, domainHasValue, pathHasValue, expiresHasValue);
 
                 webContext.Response.AppendCookie(cookie);

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WsFedCachingSecurityKeyProvider.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WsFedCachingSecurityKeyProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Owin.Security.ActiveDirectory
                 {
                     throw new InvalidOperationException(Properties.Resources.Exception_ValidatorHandlerMismatch);
                 }
-                webRequestHandler.ServerCertificateValidationCallback = backchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = backchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             RetrieveMetadata();

--- a/src/Microsoft.Owin.Security.ActiveDirectory/WsFedMetadataRetriever.cs
+++ b/src/Microsoft.Owin.Security.ActiveDirectory/WsFedMetadataRetriever.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Owin.Security.ActiveDirectory
 
         public static IssuerSigningKeys GetSigningKeys(string metadataEndpoint, TimeSpan backchannelTimeout, HttpMessageHandler backchannelHttpHandler)
         {
-            using (var metadataRequest = new HttpClient(backchannelHttpHandler, false))
+            using (var metadataRequest = new HttpClient(backchannelHttpHandler, false))// CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
             {
                 metadataRequest.Timeout = backchannelTimeout;
                 using (HttpResponseMessage metadataResponse = metadataRequest.GetAsync(metadataEndpoint).Result)

--- a/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.Facebook/FacebookAuthenticationMiddleware.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Owin.Security.Facebook
                 Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
             }
 
-            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
+            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
             _httpClient.Timeout = Options.BackchannelTimeout;
             _httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Owin.Security.Facebook
                 {
                     throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
                 }
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.Google/GoogleOAuth2AuthenticationMiddleware.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Owin.Security.Google
                 Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
             }
 
-            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
+            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
             _httpClient.Timeout = Options.BackchannelTimeout;
             _httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
         }
@@ -91,7 +91,7 @@ namespace Microsoft.Owin.Security.Google
                 {
                     throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
                 }
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security.MicrosoftAccount/MicrosoftAccountAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.MicrosoftAccount/MicrosoftAccountAuthenticationMiddleware.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
                 Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
             }
 
-            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
+            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
             _httpClient.Timeout = Options.BackchannelTimeout;
             _httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Owin.Security.MicrosoftAccount
                 {
                     throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
                 }
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.OpenIdConnect/OpenIdConnectAuthenticationMiddleware.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
 
             if (Options.Backchannel == null)
             {
-                Options.Backchannel = new HttpClient(ResolveHttpMessageHandler(Options));
+                Options.Backchannel = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
                 Options.Backchannel.DefaultRequestHeaders.UserAgent.ParseAdd("Microsoft ASP.NET Core OpenIdConnect middleware");
                 Options.Backchannel.Timeout = Options.BackchannelTimeout;
                 Options.Backchannel.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
@@ -133,7 +133,7 @@ namespace Microsoft.Owin.Security.OpenIdConnect
                     throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
                 }
 
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationHandler.cs
+++ b/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationHandler.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Owin.Security.Twitter
 
         private static string ComputeSignature(string consumerSecret, string tokenSecret, string signatureData)
         {
-            using (var algorithm = new HMACSHA1())
+            using (var algorithm = new HMACSHA1()) // CodeQL [SM02200] Required by protocol.
             {
                 algorithm.Key = Encoding.ASCII.GetBytes(
                     string.Format(CultureInfo.InvariantCulture,

--- a/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.Twitter/TwitterAuthenticationMiddleware.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Owin.Security.Twitter
                 Options.SignInAsAuthenticationType = app.GetDefaultSignInAsAuthenticationType();
             }
 
-            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
+            _httpClient = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
             _httpClient.Timeout = Options.BackchannelTimeout;
             _httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
             _httpClient.DefaultRequestHeaders.Accept.ParseAdd("*/*");
@@ -100,7 +100,7 @@ namespace Microsoft.Owin.Security.Twitter
             }
             else if (options.BackchannelCertificateValidator != null)
             {
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationMiddleware.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationMiddleware.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Owin.Security.WsFederation
                 }
                 else
                 {
-                    HttpClient httpClient = new HttpClient(ResolveHttpMessageHandler(Options));
+                    HttpClient httpClient = new HttpClient(ResolveHttpMessageHandler(Options)); // CodeQL [SM02185] Enabling certificate revocation would be a breaking change. Customers can enable it.
                     httpClient.Timeout = Options.BackchannelTimeout;
                     httpClient.MaxResponseContentBufferSize = 1024 * 1024 * 10; // 10 MB
                     Options.ConfigurationManager = new ConfigurationManager<WsFederationConfiguration>(Options.MetadataAddress,
@@ -103,7 +103,7 @@ namespace Microsoft.Owin.Security.WsFederation
                 {
                     throw new InvalidOperationException(Resources.Exception_ValidatorHandlerMismatch);
                 }
-                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
+                webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate; // CodeQL [SM03786] False positive, not disabled by default. Used for testing and extensibility.
             }
 
             return handler;

--- a/src/Microsoft.Owin.Security/CertificateSubjectPublicKeyInfoValidator.cs
+++ b/src/Microsoft.Owin.Security/CertificateSubjectPublicKeyInfoValidator.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Owin.Security
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller is responsible for disposal.")]
         private HashAlgorithm CreateHashAlgorithm()
         {
-            return _algorithm == SubjectPublicKeyInfoAlgorithm.Sha1 ? (HashAlgorithm)new SHA1CryptoServiceProvider() : new SHA256CryptoServiceProvider();
+            return _algorithm == SubjectPublicKeyInfoAlgorithm.Sha1 ? (HashAlgorithm)new SHA1CryptoServiceProvider() : new SHA256CryptoServiceProvider(); // CodeQL [SM02196] Only used to validate hashes.
         }
     }
 }

--- a/src/Microsoft.Owin.Testing/TestServer.cs
+++ b/src/Microsoft.Owin.Testing/TestServer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Owin.Testing
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposed by caller.")]
         public HttpClient HttpClient
         {
-            get { return new HttpClient(Handler) { BaseAddress = BaseAddress }; }
+            get { return new HttpClient(Handler) { BaseAddress = BaseAddress }; } // CodeQL [SM02185] This handler does not do TLS, only in-memory.
         }
 
         /// <summary>


### PR DESCRIPTION
These were mostly false positives with the exception of SM02185, server certificate revocation checks, which enabling now would be a breaking change. Customers can enable this themselves. I cleared this with @blowdart.