### PR TITLE
Fix the description of the Twitter provider to mention OAuth 1.0 instead of OAuth 2.0

### DIFF
--- a/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.csproj
+++ b/src/Microsoft.Owin.Security.Twitter/Microsoft.Owin.Security.Twitter.csproj
@@ -3,7 +3,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Microsoft.Owin.Security.Twitter</RootNamespace>
 		<TargetFramework>$(DefaultNetFxTargetFramework)</TargetFramework>
-		<description>Middleware that enables an application to support Twitter's OAuth 2.0 authentication workflow.</description>
+		<description>Middleware that enables an application to support Twitter's OAuth 1.0 authentication workflow.</description>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />


### PR DESCRIPTION
Not exactly a recent typo, but since we'll likely have a new release for the cookies stuff, it's probably a good opportunity to also fix the description of the Twitter package 😃 