### PR TITLE
Added a pre redirect notification hook

### DIFF
--- a/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationNotifications.cs
+++ b/src/Microsoft.Owin.Security.WsFederation/WsFederationAuthenticationNotifications.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Owin.Security.WsFederation
             SecurityTokenReceived = notification => Task.FromResult(0);
             SecurityTokenValidated = notification => Task.FromResult(0);
             RedirectToIdentityProvider = notification => Task.FromResult(0);
+            PreRedirectReceived = notification => Task.FromResult(0);
         }
 
         /// <summary>
@@ -50,5 +51,10 @@ namespace Microsoft.Owin.Security.WsFederation
         /// Invoked after the security token has passed validation and a ClaimsIdentity has been generated.
         /// </summary>
         public Func<SecurityTokenValidatedNotification<WsFederationMessage, WsFederationAuthenticationOptions>, Task> SecurityTokenValidated { get; set; }
+
+        /// <summary>
+        /// Invoked before redirection to hook custom redirection.
+        /// </summary>
+        public Func<PreRedirectReceivedNotification<WsFederationMessage, WsFederationAuthenticationOptions>, Task> PreRedirectReceived { get; set; }
     }
 }

--- a/src/Microsoft.Owin.Security/Notifications/PreRedirectReceivedNotification.cs
+++ b/src/Microsoft.Owin.Security/Notifications/PreRedirectReceivedNotification.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Owin.Security.Notifications
+{    public class PreRedirectReceivedNotification<TMessage, TOptions> : BaseNotification<TOptions>
+    {
+        public PreRedirectReceivedNotification(IOwinContext context, TOptions options)
+            : base(context, options)
+        {
+        }
+
+        /// <summary>
+        /// Gets or set the <see cref="AuthenticationTicket"/>
+        /// </summary>
+        public AuthenticationTicket AuthenticationTicket { get; set; }
+
+        /// <summary>
+        /// Redirection is handled by the calling application
+        /// </summary>
+        public void HandledRedirect()
+        {                        
+            AuthenticationTicket.Properties.Dictionary["HandledRedirect"] = "true";
+        }
+    }
+}


### PR DESCRIPTION
Added a pre redirect notification hook which allows the application to handle the redirection. This helps when a form is posted to the application and the request is redirected to the Identity provider. In that case when the request returns from Identity provider, all the form post values are lost and the request is changed to a GET request. This hook will allow application to save the form post values in RedirectingtoIdentityProvider event and handle the redirection as post in the application.