### PR TITLE
[release] Use -Svc pools from here on out

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ trigger:
     - main
     - release/*
     - internal/release/*
- 
+
 pr:
   autoCancel: false
   branches:
@@ -48,11 +48,11 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
 
 


### PR DESCRIPTION
- also switch to build images that exist
  - no need for ".pre" now that VS2019 is GA