### PR TITLE
Switch to a 6.0.x Arcade SDK

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22124.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.23114.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>eac1a3f1eb7404c0438664381b58d7238600aafc</Sha>
+      <Sha>0c93c1cb1ef9c9d5c1a59f4ab98c2f7e37f12197</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
     "dotnet": "6.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22124.1"
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.23114.5"
   }
 }


### PR DESCRIPTION
- align better w/ the chosen .NET SDK in this repo
- will also allow Maestro++ PRs to keep the .NET SDK up-to-date automatically