### PR TITLE
Make sure 'FromUriComponent' and 'ToUriComponent' are symmetric

### DIFF
--- a/src/Microsoft.Owin/PathString.cs
+++ b/src/Microsoft.Owin/PathString.cs
@@ -81,8 +81,7 @@ namespace Microsoft.Owin
 
             while (i < _value.Length)
             {
-                var isPercentEncodedChar = PathStringHelper.IsPercentEncodedChar(_value, i);
-                if (PathStringHelper.IsValidPathChar(_value[i]) || isPercentEncodedChar)
+                if (PathStringHelper.IsValidPathChar(_value[i]))
                 {
                     if (requiresEscaping)
                     {
@@ -99,16 +98,8 @@ namespace Microsoft.Owin
                         count = 0;
                     }
 
-                    if (isPercentEncodedChar)
-                    {
-                        count += 3;
-                        i += 3;
-                    }
-                    else
-                    {
-                        count++;
-                        i++;
-                    }
+                    count++;
+                    i++;
                 }
                 else
                 {

--- a/tests/Microsoft.Owin.Tests/PathStringTests.cs
+++ b/tests/Microsoft.Owin.Tests/PathStringTests.cs
@@ -170,11 +170,11 @@ namespace Microsoft.Owin.Tests
             singleEscapedPath.Value.ShouldBe("/one%2Ftwo");
 
             var doubleEscapedString = singleEscapedPath.ToUriComponent();
-            doubleEscapedString.ShouldBe("/one%2Ftwo");
+            doubleEscapedString.ShouldBe("/one%252Ftwo");
 
             var recreatedPath = PathString.FromUriComponent(doubleEscapedString);
-            recreatedPath.Value.ShouldBe("/one/two");
-            recreatedPath.ToUriComponent().ShouldBe("/one/two");
+            recreatedPath.Value.ShouldBe("/one%2Ftwo");
+            recreatedPath.ToUriComponent().ShouldBe("/one%252Ftwo");
         }
 
         [Theory]

--- a/tests/Microsoft.Owin.Tests/UriTests.cs
+++ b/tests/Microsoft.Owin.Tests/UriTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Owin.Tests
         [InlineData("/a%.+#?", "/z", "a#b", "http://host:1/a%25.+%23%3F/z?a%23b")]
         // Note: Http.Sys will not accept any characters in the path that it cannot un-escape,
         // so this double escaping is not a problem in production.
-        [InlineData("", "/%20", "%20", "http://host:1/%20?%20")]
+        [InlineData("", "/%20", "%20", "http://host:1/%2520?%20")]
         public void UriReconstruction(string pathBase, string path, string query, string expected)
         {
             IOwinRequest request = CreateRequest(pathBase, path, query);


### PR DESCRIPTION
This PR fixes https://github.com/aspnet/AspNetKatana/issues/393.

Currently `ToUriComponent` will skip encoding the `%` when it looks like it's part of percent-encoded character:
```
var ps = new PathString("/test%20name.txt");
Console.WriteLine("{0}", ps.ToUriComponent()); // Output: /test%20name.txt
```

However, `ToUriComponent` should output a correctly encoded version of the decoded path represented by the `PathString`:
```
var ps = new PathString("/test%20name.txt");
Console.WriteLine("{0}", ps.ToUriComponent()); // Output: /test%2520name.txt
```

Said another way, the `FromUriComponent` and `ToUriComponent` methods should be symmetrical:
```
string input = "/test%2520name.txt";
var ps = PathString.FromUriComponent(input);
string output = ps.ToUriComponent();
Console.WriteLine("{0}", input == output); // Expect this to output 'true'
```

The fix is to remove the check for percent encoding.