### PR TITLE
Update SendingHeadersEvent.cs

### DIFF
--- a/src/Microsoft.Owin.Host.SystemWeb/CallHeaders/SendingHeadersEvent.cs
+++ b/src/Microsoft.Owin.Host.SystemWeb/CallHeaders/SendingHeadersEvent.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Owin.Host.SystemWeb.CallHeaders
             for (int index = 0; index != count; ++index)
             {
                 Tuple<Action<object>, object> tuple = callbacks[count - index - 1];
-                tuple.Item1(tuple.Item2);
+                tuple?.Item1(tuple.Item2);
             }
         }
     }


### PR DESCRIPTION
@jthorpe80 mitigates #511(?)

The user is getting a null ref in this method and a null callback seems like the only way for that to happen. I don't want to add an argument null exception in Register at this point since that would just break them in a different way, even if it would help find the real culprit.

(Created on the web, need to make sure this syntax compiles in this old repo).