### PR TITLE
Update guardian.cli version

### DIFF
--- a/eng/common/sdl/packages.config
+++ b/eng/common/sdl/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Guardian.Cli" version="0.110.1"/>
+  <package id="Microsoft.Guardian.Cli" version="0.199.0"/>
 </packages>


### PR DESCRIPTION
Fixes a CG alert & matches https://github.com/dotnet/arcade/pull/15732/files

This pull request updates the version of the `Microsoft.Guardian.Cli` package in the `eng/common/sdl/packages.config` file.

* [`eng/common/sdl/packages.config`](diffhunk://#diff-d52f9db00bf45ba550ca7e15853d68390e812a3bf51ce66416ad142f4d762698L3-R3): Updated the `Microsoft.Guardian.Cli` package from version `0.110.1` to `0.199.0`.