### PR TITLE
Update branding to stable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <!-- This repo version -->
     <VersionPrefix>4.2.3</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel>rtw</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <DotNetFinalVersionKind Condition="'$(PreReleaseVersionLabel)' == 'rtw'">release</DotNetFinalVersionKind>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>


### PR DESCRIPTION
Cribbing off of https://github.com/aspnet/AspNetKatana/pull/466/files

This pull request updates the versioning information in the `eng/Versions.props` file to reflect a transition from a preview release to a release-to-web (RTW) version.

* [`eng/Versions.props`](diffhunk://#diff-1ea18ff65faa2ae6fed570b83747086d0317f5e4bc325064f6c14319a9c4ff67L5-R6): Changed `PreReleaseVersionLabel` from `preview` to `rtw` and cleared the value of `PreReleaseVersionIteration` to indicate the RTW release. Added a conditional property `DotNetFinalVersionKind` set to `release` when the label is `rtw`.